### PR TITLE
Bug/skale 1297 fix build

### DIFF
--- a/proxy/migrations/2_migration_to_schain.js
+++ b/proxy/migrations/2_migration_to_schain.js
@@ -21,6 +21,11 @@ let proxyMainnet = require("../data/proxyMainnet.json");
 let gasLimit = 8000000;
 
 async function deploy(deployer, network) {
+
+    if (network == "test" || network == "coverage") {
+        // skip this part of deployment if we run tests
+        return;
+    }
     
     if (process.env.SCHAIN_NAME == undefined || process.env.SCHAIN_NAME == "") {
         console.log(network);


### PR DESCRIPTION
I skip running of `2_migration_to_schain.js` on tests execution because it can't be ran without `SCHAIN_NAME` variable.
It prevents tests from running on travis because there is no .env file.