### PR TITLE
SKALE-3460 improved IMA agent command line for invoking tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,15 @@ jobs:
         # sudo apt-get install usbutils || true &> /dev/null
         # lsusb -t || echo "No lsusb available" || true
 
+    - name: PREPARE COVERAGE TOOLS
+      run: |
+        echo ------------ install software
+        sudo apt-get install build-essential gcc g++ gcovr lcov || true
+        echo ------------ check gcov
+        gcov --version || true
+        echo ------------ check lcov
+        lcov --version || true
+
     - name: NODE 10.x
       run: |
         echo ------------ uninstall

--- a/agent/README.md
+++ b/agent/README.md
@@ -309,6 +309,7 @@ Notice: this operation is related to ETH transfers only.
 
 Amount of money should be specified with one of the following command line options
 
+        --value=moneySpec..............Amount of eth/finney/szabo/shannon/lovelace/babbage/wei/ to transfer. For instance "1ether" or "100000wei".
         --wei=number...................Amount of wei to transfer.
         --babbage=number...............Amount of babbage(wei*1000) to transfer.
         --lovelace=number..............Amount of lovelace(wei*1000*1000) to transfer.
@@ -433,6 +434,8 @@ Performed with the **--s2m-payment**, **--no-raw-transfer** and **--addr-erc20-s
     node ./main.js --verbose=9 \
         --s2m-payment \
         --amount=1 \
+        --add-cost=10ether \
+        --sleep-between-tx=5000 \
         --url-main-net=$URL_W3_ETHEREUM \
         --url-s-chain=$URL_W3_S_CHAIN \
         --id-main-net=Mainnet \
@@ -487,6 +490,8 @@ Performed with the **--s2m-payment** and **--raw-transfer** command line options
     node ./main.js --verbose=9 \
         --s2m-payment \
         --amount=1 \
+        --add-cost=10ether \
+        --sleep-between-tx=5000 \
         --url-main-net=$URL_W3_ETHEREUM \
         --url-s-chain=$URL_W3_S_CHAIN \
         --id-main-net=Mainnet \

--- a/agent/cli.js
+++ b/agent/cli.js
@@ -477,42 +477,50 @@ function parse( joExternalHandlers ) {
             continue;
         }
         if( joArg.name == "value" ) {
-            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, joArg.value, true );
+            owaspUtils.verifyArgumentWithNonEmptyValue( joArg );
+            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, "" + joArg.value, true );
             continue;
         }
         if( joArg.name == "wei" ) {
             owaspUtils.verifyArgumentWithNonEmptyValue( joArg );
-            imaState.nAmountOfWei = joArg.value;
+            // imaState.nAmountOfWei = joArg.value * 1;
+            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, "" + joArg.value + "wei", true );
             continue;
         }
         if( joArg.name == "babbage" ) {
             owaspUtils.verifyArgumentWithNonEmptyValue( joArg );
-            imaState.nAmountOfWei = joArg.value * 1000;
+            // imaState.nAmountOfWei = joArg.value * 1000;
+            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, "" + joArg.value + "babbage", true );
             continue;
         }
         if( joArg.name == "lovelace" ) {
             owaspUtils.verifyArgumentWithNonEmptyValue( joArg );
-            imaState.nAmountOfWei = joArg.value * 1000 * 1000;
+            // imaState.nAmountOfWei = joArg.value * 1000 * 1000;
+            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, "" + joArg.value + "lovelace", true );
             continue;
         }
         if( joArg.name == "shannon" ) {
             owaspUtils.verifyArgumentWithNonEmptyValue( joArg );
-            imaState.nAmountOfWei = joArg.value * 1000 * 1000 * 1000;
+            // imaState.nAmountOfWei = joArg.value * 1000 * 1000 * 1000;
+            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, "" + joArg.value + "shannon", true );
             continue;
         }
         if( joArg.name == "szabo" ) {
             owaspUtils.verifyArgumentWithNonEmptyValue( joArg );
-            imaState.nAmountOfWei = joArg.value * 1000 * 1000 * 1000 * 1000;
+            // imaState.nAmountOfWei = joArg.value * 1000 * 1000 * 1000 * 1000;
+            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, "" + joArg.value + "szabo", true );
             continue;
         }
         if( joArg.name == "finney" ) {
             owaspUtils.verifyArgumentWithNonEmptyValue( joArg );
-            imaState.nAmountOfWei = joArg.value * 1000 * 1000 * 1000 * 1000 * 1000;
+            // imaState.nAmountOfWei = joArg.value * 1000 * 1000 * 1000 * 1000 * 1000;
+            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, "" + joArg.value + "finney", true );
             continue;
         }
         if( joArg.name == "ether" ) {
             owaspUtils.verifyArgumentWithNonEmptyValue( joArg );
-            imaState.nAmountOfWei = joArg.value * 1000 * 1000 * 1000 * 1000 * 1000 * 1000;
+            // imaState.nAmountOfWei = joArg.value * 1000 * 1000 * 1000 * 1000 * 1000 * 1000;
+            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, "" + joArg.value + "ether", true );
             continue;
         }
         if( joArg.name == "amount" ) {

--- a/agent/cli.js
+++ b/agent/cli.js
@@ -223,6 +223,7 @@ function parse( joExternalHandlers ) {
             console.log( soi + cc.debug( "--" ) + cc.bright( "key-s-chain" ) + cc.sunny( "=" ) + cc.error( "value" ) + cc.debug( "............." ) + cc.notice( "Private key for " ) + cc.note( "S-Chain" ) + cc.notice( " user account address. Value is automatically loaded from the " ) + cc.warning( "PRIVATE_KEY_FOR_SCHAIN" ) + cc.notice( " environment variable if not specified." ) );
             //
             console.log( cc.sunny( "TRANSFER" ) + cc.info( " options:" ) );
+            console.log( soi + cc.debug( "--" ) + cc.bright( "value" ) + cc.sunny( "=" ) + cc.attention( "number" ) + cc.warning( "unitName" ) + cc.debug( ".........." ) + cc.notice( "Amount of " ) + cc.attention( "unitName" ) + cc.notice( " to transfer, where " ) + cc.attention( "unitName" ) + cc.notice( " is well known Ethereum unit name like " ) + cc.attention( "ether" ) + cc.notice( " or " ) + cc.attention( "wei" ) + cc.notice( "." ) );
             console.log( soi + cc.debug( "--" ) + cc.bright( "wei" ) + cc.sunny( "=" ) + cc.attention( "number" ) + cc.debug( "...................." ) + cc.notice( "Amount of " ) + cc.attention( "wei" ) + cc.notice( " to transfer." ) );
             console.log( soi + cc.debug( "--" ) + cc.bright( "babbage" ) + cc.sunny( "=" ) + cc.attention( "number" ) + cc.debug( "................" ) + cc.notice( "Amount of " ) + cc.attention( "babbage" ) + cc.info( "(wei*1000)" ) + cc.notice( " to transfer." ) );
             console.log( soi + cc.debug( "--" ) + cc.bright( "lovelace" ) + cc.sunny( "=" ) + cc.attention( "number" ) + cc.debug( "..............." ) + cc.notice( "Amount of " ) + cc.attention( "lovelace" ) + cc.info( "(wei*1000*1000)" ) + cc.notice( " to transfer." ) );
@@ -234,6 +235,9 @@ function parse( joExternalHandlers ) {
             console.log( soi + cc.debug( "--" ) + cc.bright( "tid" ) + cc.sunny( "=" ) + cc.attention( "number" ) + cc.debug( "...................." ) + cc.attention( "ERC721" ) + cc.notice( " token id to transfer." ) );
             console.log( soi + cc.debug( "--" ) + cc.bright( "raw-transfer" ) + cc.debug( ".................." ) + cc.notice( "Perform " ) + cc.error( "raw" ) + cc.notice( " " ) + cc.attention( "ERC20" ) + cc.notice( "/" ) + cc.attention( "ERC721" ) + cc.notice( " token transfer to pre-deployed contract on S-Chain(do not instantiate new contract)." ) );
             console.log( soi + cc.debug( "--" ) + cc.bright( "no-raw-transfer" ) + cc.debug( "..............." ) + cc.notice( "Perform " ) + cc.attention( "ERC20" ) + cc.notice( "/" ) + cc.attention( "ERC721" ) + cc.notice( " token transfer to auto instantiated contract on S-Chain." ) );
+            console.log( soi + cc.debug( "--" ) + cc.bright( "add-cost" ) + cc.sunny( "=" ) + cc.attention( "number" ) + cc.warning( "unitName" ) + cc.debug( "......." ) + cc.notice( "Amount of additional ETH cost for transferring custom " ) + cc.attention( "ERC20" ) + cc.notice( "/" ) + cc.attention( "ERC721" ) + cc.notice( " tokens from " ) + cc.note( "S-chain" ) + cc.notice( " to " ) + cc.note( "Main-net" ) + cc.notice( ", where " ) + cc.attention( "unitName" ) + cc.notice( " is well known Ethereum unit name like " ) + cc.attention( "ether" ) + cc.notice( " or " ) + cc.attention( "wei" ) + cc.notice( "." ) );
+            console.log( soi + cc.debug( "--" ) + cc.bright( "sleep-between-tx" ) + cc.sunny( "=" ) + cc.attention( "number" ) + cc.debug( "......." ) + cc.notice( "Number of of " ) + cc.attention( "milliseconds" ) + cc.notice( " to sleep between transactions during complex operations." ) );
+            console.log( soi + cc.debug( "--" ) + cc.bright( "wait-next-block" ) + cc.debug( "..............." ) + cc.notice( "Wait for next block between transactions during complex operations." ) );
             //
             console.log( cc.sunny( "PAYMENT TRANSACTION" ) + cc.info( " options:" ) );
             console.log( soi + cc.debug( "--" ) + cc.bright( "gas-price-multiplier-mn" ) + cc.debug( "......." ) + cc.notice( "Sets " ) + cc.attention( "Gas Price Multiplier" ) + cc.notice( " for " ) + cc.attention( "Main Net" ) + cc.notice( " transactions, Default value is " ) + cc.info( "1.25" ) + cc.notice( ". Specify value " ) + cc.info( "0.0" ) + cc.notice( " to disable " ) + cc.attention( "Gas Price Customization" ) + cc.notice( " for " ) + cc.attention( "Main Net" ) + cc.notice( "." ) );
@@ -459,6 +463,23 @@ function parse( joExternalHandlers ) {
         }
         //
         //
+        if( joArg.name == "add-cost" ) {
+            IMA.setAmountToAddCost( owaspUtils.parseMoneySpecToWei( null, joArg.value, true ) );
+            continue;
+        }
+        if( joArg.name == "sleep-between-tx" ) {
+            owaspUtils.verifyArgumentIsInteger( joArg );
+            IMA.setSleepBetweenTransactionsOnSChainMilliseconds( joArg.value );
+            continue;
+        }
+        if( joArg.name == "wait-next-block" ) {
+            IMA.setWaitForNextBlockOnSChain( true );
+            continue;
+        }
+        if( joArg.name == "value" ) {
+            imaState.nAmountOfWei = owaspUtils.parseMoneySpecToWei( null, joArg.value, true );
+            continue;
+        }
         if( joArg.name == "wei" ) {
             owaspUtils.verifyArgumentWithNonEmptyValue( joArg );
             imaState.nAmountOfWei = joArg.value;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -283,6 +283,7 @@ Notice: this operation is related to ETH transfers only.
 Amount of money should be specified with one of the following command line options
 
 ```bash
+        --value=moneySpec..............Amount of eth/finney/szabo/shannon/lovelace/babbage/wei/ to transfer. For instance "1ether" or "100000wei".
         --wei=number...................Amount of wei to transfer.
         --babbage=number...............Amount of babbage(wei*1000) to transfer.
         --lovelace=number..............Amount of lovelace(wei*1000*1000) to transfer.
@@ -415,6 +416,8 @@ Performed with the **--s2m-payment**, **--no-raw-transfer** and **--addr-erc20-s
     node ./main.js --verbose=9 \
         --s2m-payment \
         --amount=1 \
+        --add-cost=10ether \
+        --sleep-between-tx=5000 \
         --url-main-net=http://127.0.0.1:8545 \
         --url-s-chain=http://127.0.0.1:15000 \
         --id-main-net=Mainnet \
@@ -473,6 +476,8 @@ Performed with the **--s2m-payment** and **--raw-transfer** command line options
     node ./main.js --verbose=9 \
         --s2m-payment \
         --amount=1 \
+        --add-cost=10ether \
+        --sleep-between-tx=5000 \
         --url-main-net=http://127.0.0.1:8545 \
         --url-s-chain=http://127.0.0.1:15000 \
         --id-main-net=Mainnet \

--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -118,7 +118,7 @@ function verbose_list() {
 
 let g_nSleepBetweenTransactionsOnSChainMilliseconds = 0; // example - 5000
 let g_bWaitForNextBlockOnSChain = false;
-let g_amountToAddCost = null // example - 10000000000000000", this is amount of real Eth to TokenManager.addEthConst() when sending ERC20/721 M->S
+let g_amountToAddCost = null; // example - 10000000000000000", this is amount of real Eth to TokenManager.addEthConst() when sending ERC20/721 M->S
 
 function getSleepBetweenTransactionsOnSChainMilliseconds() {
     return g_nSleepBetweenTransactionsOnSChainMilliseconds;
@@ -1062,14 +1062,11 @@ async function do_eth_payment_from_s_chain(
         strActionName = "w3_s_chain.eth.getTransactionCount()/do_eth_payment_from_s_chain";
         if( verbose_get() >= RV_VERBOSE.trace )
             log.write( strLogPrefix + cc.debug( "Will call " ) + cc.notice( strActionName ) + cc.debug( "..." ) + "\n" );
-        const tcnt = await w3_s_chain.eth.getTransactionCount( joAccountSrc.address( w3_s_chain ), null );
-        if( verbose_get() >= RV_VERBOSE.debug )
-            log.write( strLogPrefix + cc.debug( "Got " ) + cc.info( tcnt ) + cc.debug( " from " ) + cc.notice( strActionName ) + "\n" );
         //
         //
         if( g_amountToAddCost != null && g_amountToAddCost != undefined ) {
             strActionName = "w3_s_chain.eth.sendSignedTransaction()/addEthCost";
-            tcnt = parseInt( await w3_s_chain.eth.getTransactionCount( joAccountSrc.address( w3_s_chain ), null ) );
+            const tcnt = parseInt( await w3_s_chain.eth.getTransactionCount( joAccountSrc.address( w3_s_chain ), null ) );
             if( verbose_get() >= RV_VERBOSE.debug )
                 log.write( strLogPrefix + cc.debug( "Got " ) + cc.info( tcnt ) + cc.debug( " from " ) + cc.notice( strActionName ) + "\n" );
             //
@@ -1111,6 +1108,9 @@ async function do_eth_payment_from_s_chain(
             if( g_bWaitForNextBlockOnSChain )
                 await wait_for_next_block_to_appear( w3_s_chain );
         } // if( g_amountToAddCost != null && g_amountToAddCost != undefined )
+        const tcnt = await w3_s_chain.eth.getTransactionCount( joAccountSrc.address( w3_s_chain ), null );
+        if( verbose_get() >= RV_VERBOSE.debug )
+            log.write( strLogPrefix + cc.debug( "Got " ) + cc.info( tcnt ) + cc.debug( " from " ) + cc.notice( strActionName ) + "\n" );
         //
         //
         strActionName = "jo_token_manager.methods.exitToMain()/do_eth_payment_from_s_chain";

--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -116,10 +116,38 @@ function verbose_list() {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-const g_nSleepBetweenTransactionsOnSChainMilliseconds = 0;
-const g_bWaitForNextBlockOnSChain = false;
+let g_nSleepBetweenTransactionsOnSChainMilliseconds = 0; // example - 5000
+let g_bWaitForNextBlockOnSChain = false;
+let g_amountToAddCost = null // example - 10000000000000000", this is amount of real Eth to TokenManager.addEthConst() when sending ERC20/721 M->S
+
+function getSleepBetweenTransactionsOnSChainMilliseconds() {
+    return g_nSleepBetweenTransactionsOnSChainMilliseconds;
+}
+function setSleepBetweenTransactionsOnSChainMilliseconds( val ) {
+    g_nSleepBetweenTransactionsOnSChainMilliseconds = val ? val : 0;
+}
+
+function getWaitForNextBlockOnSChain() {
+    return g_bWaitForNextBlockOnSChain ? true : false;
+}
+function setWaitForNextBlockOnSChain( val ) {
+    g_bWaitForNextBlockOnSChain = val ? true : false;
+}
+
+function getAmountToAddCost() {
+    return g_amountToAddCost;
+}
+function setAmountToAddCost( val ) {
+    g_amountToAddCost = val ? val : null;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 const sleep = ( milliseconds ) => { return new Promise( resolve => setTimeout( resolve, milliseconds ) ); };
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 function parseIntSafer( s ) {
     s = s.trim();
@@ -1039,6 +1067,52 @@ async function do_eth_payment_from_s_chain(
             log.write( strLogPrefix + cc.debug( "Got " ) + cc.info( tcnt ) + cc.debug( " from " ) + cc.notice( strActionName ) + "\n" );
         //
         //
+        if( g_amountToAddCost != null && g_amountToAddCost != undefined ) {
+            strActionName = "w3_s_chain.eth.sendSignedTransaction()/addEthCost";
+            tcnt = parseInt( await w3_s_chain.eth.getTransactionCount( joAccountSrc.address( w3_s_chain ), null ) );
+            if( verbose_get() >= RV_VERBOSE.debug )
+                log.write( strLogPrefix + cc.debug( "Got " ) + cc.info( tcnt ) + cc.debug( " from " ) + cc.notice( strActionName ) + "\n" );
+            //
+            const isIgnore_addEthCost = false;
+            const methodWithArguments_addEthCost = jo_token_manager.methods.addEthCost(
+                "0x" + w3_main_net.utils.toBN( g_amountToAddCost ).toString( 16 )
+            );
+            //
+            const strDRC_addEthCost = "do_erc20_payment_from_s_chain, addEthCost";
+            await dry_run_call( w3_s_chain, methodWithArguments_addEthCost, joAccountSrc, strDRC_addEthCost, isIgnore_addEthCost );
+            dataAddEthCost = methodWithArguments_addEthCost.encodeABI();
+            //
+            const txAddEthCost = compose_tx_instance( strLogPrefix, {
+                chainId: cid_s_chain,
+                from: accountForSchain,
+                nonce: "0x" + tcnt.toString( 16 ),
+                data: dataAddEthCost,
+                to: tokenManagerAddress,
+                gasPrice: gasPrice,
+                gas: 8000000
+            } );
+            await safe_sign_transaction_with_account( txAddEthCost, joAccountSrc );
+            const serializedTxAddEthCost = txAddEthCost.serialize();
+            // let joReceiptAddEthCost = await w3_s_chain.eth.sendSignedTransaction( "0x" + serializedTxAddEthCost.toString( "hex" ) );
+            const joReceiptAddEthCost = await safe_send_signed_transaction( w3_s_chain, serializedTxAddEthCost, strActionName, strLogPrefix );
+            if( joReceiptAddEthCost && typeof joReceiptAddEthCost == "object" && "gasUsed" in joReceiptAddEthCost ) {
+                jarrReceipts.push( {
+                    "description": "do_eth_payment_from_s_chain/exit-to-main",
+                    "receipt": joReceiptAddEthCost
+                } );
+            }
+            if( verbose_get() >= RV_VERBOSE.information )
+                log.write( strLogPrefix + cc.success( "Result receipt for AddEthCost: " ) + cc.j( joReceiptAddEthCost ) + "\n" );
+            //
+            if( g_nSleepBetweenTransactionsOnSChainMilliseconds ) {
+                log.write( cc.normal( "Sleeping " ) + cc.info( g_nSleepBetweenTransactionsOnSChainMilliseconds ) + cc.normal( " milliseconds between transactions..." ) + "\n" );
+                await sleep( g_nSleepBetweenTransactionsOnSChainMilliseconds );
+            }
+            if( g_bWaitForNextBlockOnSChain )
+                await wait_for_next_block_to_appear( w3_s_chain );
+        } // if( g_amountToAddCost != null && g_amountToAddCost != undefined )
+        //
+        //
         strActionName = "jo_token_manager.methods.exitToMain()/do_eth_payment_from_s_chain";
         const methodWithArguments = jo_token_manager.methods.exitToMain(
             // call params, last is destination account on S-chain
@@ -1717,7 +1791,53 @@ async function do_erc20_payment_from_s_chain(
         }
         if( g_bWaitForNextBlockOnSChain )
             await wait_for_next_block_to_appear( w3_s_chain );
-
+        //
+        //
+        if( g_amountToAddCost != null && g_amountToAddCost != undefined ) {
+            strActionName = "w3_s_chain.eth.sendSignedTransaction()/addEthCost";
+            tcnt = parseInt( await w3_s_chain.eth.getTransactionCount( joAccountSrc.address( w3_s_chain ), null ) );
+            if( verbose_get() >= RV_VERBOSE.debug )
+                log.write( strLogPrefix + cc.debug( "Got " ) + cc.info( tcnt ) + cc.debug( " from " ) + cc.notice( strActionName ) + "\n" );
+            //
+            const isIgnore_addEthCost = false;
+            const methodWithArguments_addEthCost = jo_token_manager.methods.addEthCost(
+                "0x" + w3_main_net.utils.toBN( g_amountToAddCost ).toString( 16 )
+            );
+            //
+            const strDRC_addEthCost = "do_erc20_payment_from_s_chain, addEthCost";
+            await dry_run_call( w3_s_chain, methodWithArguments_addEthCost, joAccountSrc, strDRC_addEthCost, isIgnore_addEthCost );
+            dataAddEthCost = methodWithArguments_addEthCost.encodeABI();
+            //
+            const txAddEthCost = compose_tx_instance( strLogPrefix, {
+                chainId: cid_s_chain,
+                from: accountForSchain,
+                nonce: "0x" + tcnt.toString( 16 ),
+                data: dataAddEthCost,
+                to: tokenManagerAddress,
+                gasPrice: gasPrice,
+                gas: 8000000
+            } );
+            await safe_sign_transaction_with_account( txAddEthCost, joAccountSrc );
+            const serializedTxAddEthCost = txAddEthCost.serialize();
+            // let joReceiptAddEthCost = await w3_s_chain.eth.sendSignedTransaction( "0x" + serializedTxAddEthCost.toString( "hex" ) );
+            const joReceiptAddEthCost = await safe_send_signed_transaction( w3_s_chain, serializedTxAddEthCost, strActionName, strLogPrefix );
+            if( joReceiptAddEthCost && typeof joReceiptAddEthCost == "object" && "gasUsed" in joReceiptAddEthCost ) {
+                jarrReceipts.push( {
+                    "description": "do_erc20_payment_from_s_chain/exit-to-main",
+                    "receipt": joReceiptAddEthCost
+                } );
+            }
+            if( verbose_get() >= RV_VERBOSE.information )
+                log.write( strLogPrefix + cc.success( "Result receipt for AddEthCost: " ) + cc.j( joReceiptAddEthCost ) + "\n" );
+            //
+            if( g_nSleepBetweenTransactionsOnSChainMilliseconds ) {
+                log.write( cc.normal( "Sleeping " ) + cc.info( g_nSleepBetweenTransactionsOnSChainMilliseconds ) + cc.normal( " milliseconds between transactions..." ) + "\n" );
+                await sleep( g_nSleepBetweenTransactionsOnSChainMilliseconds );
+            }
+            if( g_bWaitForNextBlockOnSChain )
+                await wait_for_next_block_to_appear( w3_s_chain );
+        } // if( g_amountToAddCost != null && g_amountToAddCost != undefined )
+        //
         //
         strActionName = "w3_s_chain.eth.sendSignedTransaction()/ExitToMainERC20";
         tcnt = parseInt( await w3_s_chain.eth.getTransactionCount( joAccountSrc.address( w3_s_chain ), null ) );
@@ -1876,7 +1996,53 @@ async function do_erc721_payment_from_s_chain(
         }
         if( g_bWaitForNextBlockOnSChain )
             await wait_for_next_block_to_appear( w3_s_chain );
-
+        //
+        //
+        if( g_amountToAddCost != null && g_amountToAddCost != undefined ) {
+            strActionName = "w3_s_chain.eth.sendSignedTransaction()/addEthCost";
+            tcnt = parseInt( await w3_s_chain.eth.getTransactionCount( joAccountSrc.address( w3_s_chain ), null ) );
+            if( verbose_get() >= RV_VERBOSE.debug )
+                log.write( strLogPrefix + cc.debug( "Got " ) + cc.info( tcnt ) + cc.debug( " from " ) + cc.notice( strActionName ) + "\n" );
+            //
+            const isIgnore_addEthCost = false;
+            const methodWithArguments_addEthCost = jo_token_manager.methods.addEthCost(
+                "0x" + w3_main_net.utils.toBN( g_amountToAddCost ).toString( 16 )
+            );
+            //
+            const strDRC_addEthCost = "do_erc20_payment_from_s_chain, addEthCost";
+            await dry_run_call( w3_s_chain, methodWithArguments_addEthCost, joAccountSrc, strDRC_addEthCost, isIgnore_addEthCost );
+            dataAddEthCost = methodWithArguments_addEthCost.encodeABI();
+            //
+            const txAddEthCost = compose_tx_instance( strLogPrefix, {
+                chainId: cid_s_chain,
+                from: accountForSchain,
+                nonce: "0x" + tcnt.toString( 16 ),
+                data: dataAddEthCost,
+                to: tokenManagerAddress,
+                gasPrice: gasPrice,
+                gas: 8000000
+            } );
+            await safe_sign_transaction_with_account( txAddEthCost, joAccountSrc );
+            const serializedTxAddEthCost = txAddEthCost.serialize();
+            // let joReceiptAddEthCost = await w3_s_chain.eth.sendSignedTransaction( "0x" + serializedTxAddEthCost.toString( "hex" ) );
+            const joReceiptAddEthCost = await safe_send_signed_transaction( w3_s_chain, serializedTxAddEthCost, strActionName, strLogPrefix );
+            if( joReceiptAddEthCost && typeof joReceiptAddEthCost == "object" && "gasUsed" in joReceiptAddEthCost ) {
+                jarrReceipts.push( {
+                    "description": "do_erc721_payment_from_s_chain/exit-to-main",
+                    "receipt": joReceiptAddEthCost
+                } );
+            }
+            if( verbose_get() >= RV_VERBOSE.information )
+                log.write( strLogPrefix + cc.success( "Result receipt for AddEthCost: " ) + cc.j( joReceiptAddEthCost ) + "\n" );
+            //
+            if( g_nSleepBetweenTransactionsOnSChainMilliseconds ) {
+                log.write( cc.normal( "Sleeping " ) + cc.info( g_nSleepBetweenTransactionsOnSChainMilliseconds ) + cc.normal( " milliseconds between transactions..." ) + "\n" );
+                await sleep( g_nSleepBetweenTransactionsOnSChainMilliseconds );
+            }
+            if( g_bWaitForNextBlockOnSChain )
+                await wait_for_next_block_to_appear( w3_s_chain );
+        } // if( g_amountToAddCost != null && g_amountToAddCost != undefined )
+        //
         //
         strActionName = "w3_s_chain.eth.sendSignedTransaction()/ExitToMainERC721";
         tcnt = await w3_s_chain.eth.getTransactionCount( joAccountSrc.address( w3_s_chain ), null );
@@ -2473,6 +2639,13 @@ module.exports.tc_main_net = tc_main_net;
 module.exports.tc_s_chain = tc_s_chain;
 
 module.exports.compose_tx_instance = compose_tx_instance;
+
+module.exports.getSleepBetweenTransactionsOnSChainMilliseconds = getSleepBetweenTransactionsOnSChainMilliseconds;
+module.exports.setSleepBetweenTransactionsOnSChainMilliseconds = setSleepBetweenTransactionsOnSChainMilliseconds;
+module.exports.getWaitForNextBlockOnSChain = getWaitForNextBlockOnSChain;
+module.exports.setWaitForNextBlockOnSChain = setWaitForNextBlockOnSChain;
+module.exports.getAmountToAddCost = getAmountToAddCost;
+module.exports.setAmountToAddCost = setAmountToAddCost;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -960,7 +960,7 @@ async function do_eth_payment_from_main_net(
             gas: 3000000, // 2100000
             to: jo_deposit_box.options.address, // contract address
             data: dataTx,
-            value: wei_how_much // how much money to send
+            value: "0x" + w3_main_net.utils.toBN( wei_how_much ).toString( 16 ) // wei_how_much // how much money to send
         } );
         await safe_sign_transaction_with_account( tx, joAccountSrc );
         const serializedTx = tx.serialize();

--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -1062,7 +1062,11 @@ async function do_eth_payment_from_s_chain(
         strActionName = "w3_s_chain.eth.getTransactionCount()/do_eth_payment_from_s_chain";
         if( verbose_get() >= RV_VERBOSE.trace )
             log.write( strLogPrefix + cc.debug( "Will call " ) + cc.notice( strActionName ) + cc.debug( "..." ) + "\n" );
+        const tokenManagerAddress = jo_token_manager.options.address;
         //
+        const gasPrice = await tc_s_chain.computeGasPrice( w3_s_chain, 10000000000 );
+        if( verbose_get() >= RV_VERBOSE.debug )
+            log.write( strLogPrefix + cc.debug( "Using computed " ) + cc.info( "gasPrice" ) + cc.debug( "=" ) + cc.notice( gasPrice ) + "\n" ); //
         //
         if( g_amountToAddCost != null && g_amountToAddCost != undefined ) {
             strActionName = "w3_s_chain.eth.sendSignedTransaction()/addEthCost";
@@ -1072,7 +1076,7 @@ async function do_eth_payment_from_s_chain(
             //
             const isIgnore_addEthCost = false;
             const methodWithArguments_addEthCost = jo_token_manager.methods.addEthCost(
-                "0x" + w3_main_net.utils.toBN( g_amountToAddCost ).toString( 16 )
+                "0x" + w3_s_chain.utils.toBN( g_amountToAddCost ).toString( 16 )
             );
             //
             const strDRC_addEthCost = "do_erc20_payment_from_s_chain, addEthCost";
@@ -1081,7 +1085,7 @@ async function do_eth_payment_from_s_chain(
             //
             const txAddEthCost = compose_tx_instance( strLogPrefix, {
                 chainId: cid_s_chain,
-                from: accountForSchain,
+                from: joAccountSrc.address( w3_s_chain ),
                 nonce: "0x" + tcnt.toString( 16 ),
                 data: dataAddEthCost,
                 to: tokenManagerAddress,
@@ -1124,10 +1128,6 @@ async function do_eth_payment_from_s_chain(
         const strDRC = "do_eth_payment_from_s_chain, exitToMain";
         await dry_run_call( w3_s_chain, methodWithArguments, joAccountSrc, strDRC, isIgnore );
         const dataTx = methodWithArguments.encodeABI(); // the encoded ABI of the method
-        //
-        const gasPrice = await tc_s_chain.computeGasPrice( w3_s_chain, 10000000000 );
-        if( verbose_get() >= RV_VERBOSE.debug )
-            log.write( strLogPrefix + cc.debug( "Using computed " ) + cc.info( "gasPrice" ) + cc.debug( "=" ) + cc.notice( gasPrice ) + "\n" );
         //
         const tx = compose_tx_instance( strLogPrefix, {
             chainId: cid_s_chain,

--- a/npms/skale-owasp/owasp-util.js
+++ b/npms/skale-owasp/owasp-util.js
@@ -363,6 +363,124 @@ function private_key_2_account_address( w3, keyPrivate ) {
     return strAddress;
 }
 
+// example: "1ether" -> "1000000000000000000"
+// supported suffixes, lowercase
+// const g_arrMoneyNameSuffixes = [ "ether", "finney", "szabo", "shannon", "lovelace", "babbage", "wei" ];
+
+// supported suffix aliases, lowercase
+const g_mapMoneyNameSuffixAliases = {
+    "ethe": "ether",
+    "ethr": "ether",
+    "eth": "ether",
+    "eter": "ether",
+    "ete": "ether",
+    "et": "ether",
+    "eh": "ether",
+    "er": "ether",
+    // "e": "ether",
+    "finne": "finney",
+    "finn": "finney",
+    "fin": "finney",
+    "fn": "finney",
+    "fi": "finney",
+    // "f": "finney",
+    "szab": "szabo",
+    "szb": "szabo",
+    "sza": "szabo",
+    "sz": "szabo",
+    "shanno": "shannon",
+    "shannn": "shannon",
+    "shann": "shannon",
+    "shan": "shannon",
+    "sha": "shannon",
+    "shn": "shannon",
+    "sh": "shannon",
+    "lovelac": "lovelace",
+    "lovela": "lovelace",
+    "lovel": "lovelace",
+    "love": "lovelace",
+    "lovl": "lovelace",
+    "lvl": "lovelace",
+    "lvla": "lovelace",
+    "lvlc": "lovelace",
+    "lvc": "lovelace",
+    "lv": "lovelace",
+    "lo": "lovelace",
+    "lc": "lovelace",
+    "ll": "lovelace",
+    // "l": "lovelace",
+    "babbag": "babbage",
+    "babba": "babbage",
+    "babbg": "babbage",
+    "babb": "babbage",
+    "bab": "babbage",
+    "bag": "babbage",
+    "bbb": "babbage",
+    "bb": "babbage",
+    "bg": "babbage",
+    "ba": "babbage",
+    "be": "babbage",
+    // "b": "babbage",
+    "we": "wei",
+    "wi": "wei"
+    // "w": "wei"
+};
+
+function parseMoneyUnitName( s ) {
+    s = s.trim().toLowerCase();
+    if( s == "" )
+        return "wei";
+    if( s in g_mapMoneyNameSuffixAliases ) {
+        s = g_mapMoneyNameSuffixAliases[s];
+        return s;
+    }
+    // if( g_arrMoneyNameSuffixes.indexOf( s ) >= 0 )
+    //     return s;
+    // throw new Error( "\"" + s + "\" is unknown money unit name" );
+    return s;
+}
+
+function is_numeric( s ) {
+    return /^\d+$/.test( s );
+}
+
+function parseMoneySpecToWei( w3, s, isThrowException ) {
+    try {
+        w3 = w3 || global.w3mod;
+        isThrowException = isThrowException ? true : false;
+        if( s == null || s == undefined ) {
+            if( isThrowException )
+                throw new Error( "no parse-able value provided" );
+            return "0";
+        }
+        s = s.toString().trim();
+        let strNumber = "";
+        while( s.length > 0 ) {
+            const chr = s[0];
+            if( is_numeric( chr ) || chr == "." ) {
+                strNumber += chr;
+                s = s.substr( 1 ); // remove first character
+                continue;
+            }
+            if( chr == " " || chr == "\t" || chr == "\r" || chr == "\n" )
+                s = s.substr( 1 ); // remove first character
+            s = s.trim().toLowerCase();
+            break;
+        }
+        // here s is rest suffix string, number is number as string or empty string
+        if( strNumber == "" )
+            throw new Error( "no number or float value found" );
+        s = parseMoneyUnitName( s );
+        s = w3.utils.toWei( strNumber, s );
+        s = s.toString( 10 );
+        return s;
+    } catch ( err ) {
+        if( isThrowException )
+            throw new Error( "Parse error in parseMoneySpecToWei(\"" + s + "\"), error is: " + err.toString() );
+    }
+    return "0";
+}
+
 module.exports = {
     cc: cc,
     w3mod: w3mod,
@@ -394,5 +512,8 @@ module.exports = {
     remove_starting_0x: remove_starting_0x,
     private_key_2_public_key: private_key_2_public_key,
     public_key_2_account_address: public_key_2_account_address,
-    private_key_2_account_address: private_key_2_account_address
+    private_key_2_account_address: private_key_2_account_address,
+    is_numeric: is_numeric,
+    parseMoneyUnitName: parseMoneyUnitName,
+    parseMoneySpecToWei: parseMoneySpecToWei
 }; // module.exports


### PR DESCRIPTION
This pull request is test improvement. It does not change behavior of IMA agent running transfer loop on a cloud machine. It adds features needed for newest ALL-SKALE/functional test:
- added `--value=???` command line argument which allows to specify amount of ETH to transfer in various commonly used Etherum money units like `1ether`, `100lovelace` or `1000000wei`.
- added `--add-cost=???` command line argument which allows to specify amount of ETH to pass to `TransactionManager.addEthCost()` API when sending from S-Chain to Main Net.
- added `--sleep-between-tx=milliseconds`command line argument which allows to specify time to sleep between transactions when performing complex operations.
- added `--wait-next-block` command line flag which specifies IMA agent to wait +1 next block appear before executing next transaction as part of complex operation.
- implemented safe value parsing for huge transfer amounts specified in `wei`.