### PR TITLE
Enhancement/skale 4086 fix erc721 vulnerability

### DIFF
--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -2276,10 +2276,12 @@ async function do_erc721_payment_from_s_chain(
         const contractERC721 = new w3_s_chain.eth.Contract( erc721ABI, erc721Address_s_chain );
         // prepare the smart contract function deposit(string schainID, address to)
         // const depositBoxAddress = jo_deposit_box.options.address;
-        const methodWithArguments_transferFrom = contractERC721.methods.transferFrom(
-            accountForSchain, tokenManagerAddress, "0x" + w3_main_net.utils.toBN( token_id ).toString( 16 )
+        const methodWithArguments_approve = contractERC721.methods.approve(
+            // accountForSchain,
+            tokenManagerAddress,
+            "0x" + w3_main_net.utils.toBN( token_id ).toString( 16 )
         );
-        const dataTxTransferFrom = methodWithArguments_transferFrom.encodeABI();
+        const dataTxApprove = methodWithArguments_approve.encodeABI();
         let dataTxExitToMainERC721 = null;
         const erc721Address_main_net = joErc721_main_net[strCoinNameErc721_main_net + "_address"];
         const methodWithArguments_rawExitToMainERC721 = jo_token_manager.methods.exitToMainERC721(
@@ -2297,45 +2299,45 @@ async function do_erc721_payment_from_s_chain(
             log.write( strLogPrefix + cc.debug( "Using computed " ) + cc.info( "gasPrice" ) + cc.debug( "=" ) + cc.notice( gasPrice ) + "\n" );
         //
         //
-        strActionName = "create ERC721/transferFrom transaction S->M";
+        strActionName = "create ERC721/approve transaction S->M";
         let tcnt = parseInt( await get_web3_transactionCount( 10, w3_s_chain, joAccountSrc.address( w3_s_chain ), null ) );
         if( verbose_get() >= RV_VERBOSE.debug )
             log.write( strLogPrefix + cc.debug( "Got " ) + cc.info( tcnt ) + cc.debug( " from " ) + cc.notice( strActionName ) + "\n" );
         //
-        const estimatedGas_transferFrom = await tc_s_chain.computeGas( methodWithArguments_transferFrom, w3_s_chain, 8000000, gasPrice, joAccountSrc.address( w3_s_chain ), "0" );
+        const estimatedGas_approve = await tc_s_chain.computeGas( methodWithArguments_approve, w3_s_chain, 8000000, gasPrice, joAccountSrc.address( w3_s_chain ), "0" );
         if( verbose_get() >= RV_VERBOSE.debug )
-            log.write( strLogPrefix + cc.debug( "Using estimated(transfer from) " ) + cc.info( "gas" ) + cc.debug( "=" ) + cc.notice( estimatedGas_transferFrom ) + "\n" );
+            log.write( strLogPrefix + cc.debug( "Using estimated(transfer from) " ) + cc.info( "gas" ) + cc.debug( "=" ) + cc.notice( estimatedGas_approve ) + "\n" );
         //
-        const isIgnore_transferFrom = false;
-        const strDRC_transferFrom = "erc721_payment_from_s_chain, transferFrom";
-        await dry_run_call( w3_s_chain, methodWithArguments_transferFrom, joAccountSrc, strDRC_transferFrom,isIgnore_transferFrom, gasPrice, estimatedGas_transferFrom, "0" );
+        const isIgnore_approve = false;
+        const strDRC_approve = "erc721_payment_from_s_chain, approve";
+        await dry_run_call( w3_s_chain, methodWithArguments_approve, joAccountSrc, strDRC_approve,isIgnore_approve, gasPrice, estimatedGas_approve, "0" );
         //
-        const rawTxTransferFrom = {
+        const rawTxApprove = {
             chainId: cid_s_chain,
             from: accountForSchain,
             nonce: "0x" + tcnt.toString( 16 ),
-            data: dataTxTransferFrom,
+            data: dataTxApprove,
             to: erc721Address_s_chain,
             gasPrice: gasPrice,
-            gas: estimatedGas_transferFrom
+            gas: estimatedGas_approve
         };
-        const txTransferFrom = compose_tx_instance( strLogPrefix, rawTxTransferFrom );
-        strActionName = "sign ERC721/transferFrom transaction S->M";
-        const joTransferFromSR = await safe_sign_transaction_with_account( w3_s_chain, txTransferFrom, rawTxTransferFrom, joAccountSrc );
-        let joReceiptTransferFrom = null;
-        if( joTransferFromSR.joACI.isAutoSend )
-            joReceiptTransferFrom = await get_web3_transactionReceipt( 10, w3_s_chain, joTransferFromSR.txHashSent );
+        const txApprove = compose_tx_instance( strLogPrefix, rawTxApprove );
+        strActionName = "sign ERC721/approve transaction S->M";
+        const joApproveSR = await safe_sign_transaction_with_account( w3_s_chain, txApprove, rawTxApprove, joAccountSrc );
+        let joReceiptApprove = null;
+        if( joApproveSR.joACI.isAutoSend )
+            joReceiptApprove = await get_web3_transactionReceipt( 10, w3_s_chain, joApproveSR.txHashSent );
         else {
-            const serializedTxTransferFrom = txTransferFrom.serialize();
-            // let joReceiptTransferFrom = await w3_s_chain.eth.sendSignedTransaction( "0x" + serializedTxTransferFrom.toString( "hex" ) );
-            joReceiptTransferFrom = await safe_send_signed_transaction( w3_s_chain, serializedTxTransferFrom, strActionName, strLogPrefix );
+            const serializedTxApprove = txApprove.serialize();
+            // let joReceiptApprove = await w3_s_chain.eth.sendSignedTransaction( "0x" + serializedTxApprove.toString( "hex" ) );
+            joReceiptApprove = await safe_send_signed_transaction( w3_s_chain, serializedTxApprove, strActionName, strLogPrefix );
         }
         if( verbose_get() >= RV_VERBOSE.information )
-            log.write( strLogPrefix + cc.success( "Result receipt for TransferFrom: " ) + cc.j( joReceiptTransferFrom ) + "\n" );
-        if( joReceiptTransferFrom && typeof joReceiptTransferFrom == "object" && "gasUsed" in joReceiptTransferFrom ) {
+            log.write( strLogPrefix + cc.success( "Result receipt for Approve: " ) + cc.j( joReceiptApprove ) + "\n" );
+        if( joReceiptApprove && typeof joReceiptApprove == "object" && "gasUsed" in joReceiptApprove ) {
             jarrReceipts.push( {
                 "description": "do_erc721_payment_from_s_chain/transfer-from",
-                "receipt": joReceiptTransferFrom
+                "receipt": joReceiptApprove
             } );
         }
         //

--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -1687,8 +1687,10 @@ async function do_erc721_payment_from_main_net(
         // prepare the smart contract function deposit(string schainID, address to)
         const depositBoxAddress = jo_deposit_box_erc721.options.address;
         const accountForSchain = joAccountDst.address( w3_s_chain );
-        const methodWithArguments_approve = contractERC721.methods.transferFrom( // same as approve in 20
-            joAccountSrc.address( w3_main_net ), depositBoxAddress, "0x" + w3_main_net.utils.toBN( token_id ).toString( 16 )
+        const methodWithArguments_approve = contractERC721.methods.approve( // same as approve in 20
+            // joAccountSrc.address( w3_main_net ),
+            depositBoxAddress,
+            "0x" + w3_main_net.utils.toBN( token_id ).toString( 16 )
         );
         const dataTxApprove = methodWithArguments_approve.encodeABI();
         let dataTxDeposit = null;

--- a/proxy/contracts/DepositBoxERC20.sol
+++ b/proxy/contracts/DepositBoxERC20.sol
@@ -72,6 +72,10 @@ contract DepositBoxERC20 is IMAConnected, IDepositBox {
         bytes32 schainHash = keccak256(abi.encodePacked(schainID));
         address tokenManagerAddress = tokenManagerERC20Addresses[schainHash];
         require(tokenManagerAddress != address(0), "Unconnected chain");
+        require(
+            IERC20Metadata(contractOnMainnet).allowance(msg.sender, address(this)) >= amount,
+            "DepositBox was not approved for ERC20 token"
+        );
         bytes memory data = _receiveERC20(
             schainID,
             contractOnMainnet,

--- a/proxy/contracts/DepositBoxERC721.sol
+++ b/proxy/contracts/DepositBoxERC721.sol
@@ -67,8 +67,8 @@ contract DepositBoxERC721 is IMAConnected, IDepositBox {
         address tokenManagerAddress = tokenManagerERC721Addresses[schainHash];
         require(tokenManagerAddress != address(0), "Unconnected chain");
         require(
-            IERC721Upgradeable(contractOnMainnet).ownerOf(tokenId) == address(this),
-            "Did not transfer ERC721 token"
+            IERC721Upgradeable(contractOnMainnet).getApproved(tokenId) == address(this),
+            "DepositBox was not approved for ERC721 token"
         );
         bytes memory data = _receiveERC721(
             schainID,
@@ -76,6 +76,7 @@ contract DepositBoxERC721 is IMAConnected, IDepositBox {
             to,
             tokenId
         );
+        IERC721Upgradeable(contractOnMainnet).transferFrom(msg.sender, address(this), tokenId);
         messageProxy.postOutgoingMessage(
             schainHash,
             tokenManagerAddress,

--- a/proxy/contracts/IMALinker.sol
+++ b/proxy/contracts/IMALinker.sol
@@ -2,7 +2,7 @@
 
 /**
  *   IMALinker.sol - SKALE Interchain Messaging Agent
- *   Copyright (C) 2019-Present SKALE Labs
+ *   Copyright (C) 2021-Present SKALE Labs
  *   @author Artem Payvin
  *
  *   SKALE IMA is free software: you can redistribute it and/or modify

--- a/proxy/contracts/predeployed/TokenManager.sol
+++ b/proxy/contracts/predeployed/TokenManager.sol
@@ -228,8 +228,8 @@ contract TokenManager is PermissionsForSchain {
         address erc721Module = LockAndDataForSchain(getLockAndDataAddress()).getErc721Module();
         address contractOnSchain = ILockAndDataERCOnSchain(lockAndDataERC721)
             .getERC721OnSchain("Mainnet", contractOnMainnet);
-        require(IERC721(contractOnSchain).ownerOf(tokenId) == address(this), "Not allowed ERC721 Token");
-        IERC721(contractOnSchain).transferFrom(address(this), lockAndDataERC721, tokenId);
+        require(IERC721(contractOnSchain).getApproved(tokenId) == address(this), "Not allowed ERC721 Token");
+        IERC721(contractOnSchain).transferFrom(msg.sender, lockAndDataERC721, tokenId);
         require(IERC721(contractOnSchain).ownerOf(tokenId) == lockAndDataERC721, "Did not transfer ERC721 token");
         // require(amountOfEth >= TX_FEE, "Not enough funds to exit");
         // uint amountOfEthToSend = amountOfEth >= TX_FEE ?
@@ -261,8 +261,8 @@ contract TokenManager is PermissionsForSchain {
         address erc721Module = LockAndDataForSchain(getLockAndDataAddress()).getErc721Module();
         address contractOnSchain = ILockAndDataERCOnSchain(lockAndDataERC721)
             .getERC721OnSchain(schainID, contractOnMainnet);
-        require(IERC721(contractOnSchain).ownerOf(tokenId) == address(this), "Not allowed ERC721 Token");
-        IERC721(contractOnSchain).transferFrom(address(this), lockAndDataERC721, tokenId);
+        require(IERC721(contractOnSchain).getApproved(tokenId) == address(this), "Not allowed ERC721 Token");
+        IERC721(contractOnSchain).transferFrom(msg.sender, lockAndDataERC721, tokenId);
         require(IERC721(contractOnSchain).ownerOf(tokenId) == lockAndDataERC721, "Did not transfer ERC721 token");
         bytes memory data = ERC721ModuleForSchain(erc721Module).receiveERC721(
             schainID,

--- a/proxy/gas/calculateGas.ts
+++ b/proxy/gas/calculateGas.ts
@@ -330,25 +330,25 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         let res = await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
         console.log("Registration of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
         console.log("First transfer of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
         console.log("Second transfer of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
         console.log("Third transfer of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
         console.log("Forth transfer of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
         console.log("Fifth transfer of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 6, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 6, {from: user});
         console.log("Sixth transfer of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 7, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 7, {from: user});
         console.log("Seventh transfer of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 8, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 8, {from: user});
         console.log("Eighth transfer of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 9, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 9, {from: user});
         console.log("Ninth transfer of ERC721 token cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 10, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 10, {from: user});
         console.log("Tenth transfer of ERC721 token cost:", res.receipt.gasUsed);
     });
 
@@ -356,16 +356,16 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 6, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 7, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 8, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 9, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 10, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 6, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 7, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 8, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 9, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 10, {from: user});
 
         let res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 1, {from: user});
         console.log("First deposit erc721 cost:", res.receipt.gasUsed);
@@ -394,43 +394,43 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
 
-        let res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
+        let res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
         console.log("First transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 1, {from: user});
         console.log("First deposit erc721 cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
         console.log("Second transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 2, {from: user});
         console.log("Second deposit erc721 cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
         console.log("Third transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 3, {from: user});
         console.log("Third deposit erc721 cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
         console.log("Forth transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 4, {from: user});
         console.log("Forth deposit erc721 cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
         console.log("Fifth transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 5, {from: user});
         console.log("Fifth deposit erc721 cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 6, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 6, {from: user});
         console.log("Sixth transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 6, {from: user});
         console.log("Sixth deposit erc721 cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 7, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 7, {from: user});
         console.log("Seventh transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 7, {from: user});
         console.log("Seventh deposit erc721 cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 8, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 8, {from: user});
         console.log("Eighth transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 8, {from: user});
         console.log("Eighth deposit erc721 cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 9, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 9, {from: user});
         console.log("Ninth transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 9, {from: user});
         console.log("Ninth deposit erc721 cost:", res.receipt.gasUsed);
-        res = await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 10, {from: user});
+        res = await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 10, {from: user});
         console.log("Tenth transfer of ERC721 token cost:", res.receipt.gasUsed);
         res = await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 10, {from: user});
         console.log("Tenth deposit erc721 cost:", res.receipt.gasUsed);
@@ -2094,11 +2094,11 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register ERC721 tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
 
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 1, {from: user});
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 2, {from: user});
@@ -2220,11 +2220,11 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register ERC721 tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
 
         // prepare exit message of 1 erc721 token - await TokenManager.exitToMainERC721(ERC721TokenOnMainnet.address, user, 1, "1000000000000000000", {from: user});
         const dataOfERC721OfToken1 = await messages.encodeTransferErc721Message(ERC721TokenOnMainnet.address, user, 1);
@@ -2345,11 +2345,11 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register ERC721 tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
 
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 1, {from: user});
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 2, {from: user});
@@ -2453,11 +2453,11 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register ERC721 tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
 
         // prepare exit message of 1 erc721 token - await TokenManager.exitToMainERC721(ERC721TokenOnMainnet.address, user, 1, "1000000000000000000", {from: user});
         const dataOfERC721OfToken1 = await messages.encodeTransferErc721Message(ERC721TokenOnMainnet.address, user, 1);
@@ -2560,11 +2560,11 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register ERC721 tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
 
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 1, {from: user});
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 2, {from: user});
@@ -2659,11 +2659,11 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register ERC721 tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
 
         // prepare exit message of 1 erc721 token - await TokenManager.exitToMainERC721(ERC721TokenOnMainnet.address, user, 1, "1000000000000000000", {from: user});
         const dataOfERC721OfToken1 = await messages.encodeTransferErc721Message(ERC721TokenOnMainnet.address, user, 1);
@@ -2757,11 +2757,11 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register ERC721 tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
 
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 1, {from: user});
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 2, {from: user});
@@ -2856,11 +2856,11 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register ERC721 tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
 
         // prepare exit message of 1 erc721 token - await TokenManager.exitToMainERC721(ERC721TokenOnMainnet.address, user, 1, "1000000000000000000", {from: user});
         const dataOfERC721OfToken1 = await messages.encodeTransferErc721Message(ERC721TokenOnMainnet.address, user, 1);
@@ -2954,11 +2954,11 @@ contract("Gas calculation", ([deployer, schainOwner, user]) => {
         // register ERC721 tokens
         await lockAndDataForSchainERC721.addERC721TokenByOwner("Mainnet", ERC721TokenOnMainnet.address, ERC721TokenOnSchain.address, {from: deployer});
         await depositBoxERC721.addERC721TokenByOwner(schainName, ERC721TokenOnMainnet.address, {from: deployer});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 1, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 2, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 3, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 4, {from: user});
-        await ERC721TokenOnMainnet.transferFrom(user, depositBoxERC721.address, 5, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 1, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 2, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 3, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 4, {from: user});
+        await ERC721TokenOnMainnet.approve(depositBoxERC721.address, 5, {from: user});
 
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 1, {from: user});
         await depositBoxERC721.depositERC721(schainName, ERC721TokenOnMainnet.address, user, 2, {from: user});

--- a/proxy/test/DepositBox.spec.ts
+++ b/proxy/test/DepositBox.spec.ts
@@ -327,7 +327,7 @@ contract("DepositBox", ([deployer, user, user2]) => {
       await messageProxy.addConnectedChain(schainID, {from: deployer});
       await initializeSchain(contractManager, schainID, deployer, 1, 1);
       await setCommonPublicKey(contractManager, schainID);
-      await rechargeSchainWallet(contractManager, schainID, "1000000000000000000");
+      await rechargeSchainWallet(contractManager, schainID, deployer, "1000000000000000000");
       // execution
 
       const res = await messageProxy.postIncomingMessages(schainID, 0, [message], sign, 0, {from: deployer});
@@ -367,7 +367,7 @@ contract("DepositBox", ([deployer, user, user2]) => {
         .connectSchain(schainID, [deployer, deployer, deployer], {from: deployer});
       await initializeSchain(contractManager, schainID, deployer, 1, 1);
       await setCommonPublicKey(contractManager, schainID);
-      await rechargeSchainWallet(contractManager, schainID, "1000000000000000000");
+      await rechargeSchainWallet(contractManager, schainID, deployer, "1000000000000000000");
       // execution
       const res = await messageProxy.postIncomingMessages(schainID, 0, [message], sign, 0, {from: deployer});
 
@@ -388,7 +388,7 @@ contract("DepositBox", ([deployer, user, user2]) => {
 
       await initializeSchain(contractManager, schainID, deployer, 1, 1);
       await setCommonPublicKey(contractManager, schainID);
-      await rechargeSchainWallet(contractManager, schainID, "1000000000000000000");
+      await rechargeSchainWallet(contractManager, schainID, deployer, "1000000000000000000");
 
       const sign = {
         blsSignature: BlsSignature,
@@ -429,7 +429,7 @@ contract("DepositBox", ([deployer, user, user2]) => {
 
       await initializeSchain(contractManager, schainID, deployer, 1, 1);
       await setCommonPublicKey(contractManager, schainID);
-      await rechargeSchainWallet(contractManager, schainID, "1000000000000000000");
+      await rechargeSchainWallet(contractManager, schainID, deployer, "1000000000000000000");
 
       const sign = {
         blsSignature: BlsSignature,
@@ -489,7 +489,7 @@ contract("DepositBox", ([deployer, user, user2]) => {
       // add schain to avoid the `Receiver chain is incorrect` error
 
       await initializeSchain(contractManager, schainID, deployer, 1, 1);
-      await rechargeSchainWallet(contractManager, schainID, "1000000000000000000");
+      await rechargeSchainWallet(contractManager, schainID, deployer, "1000000000000000000");
       const chain = await imaLinker
         .connectSchain(schainID, [deployer, deployer, deployer], {from: deployer});
       // add wei to contract through `receiveEth` because `receiveEth` have `payable` parameter
@@ -527,7 +527,7 @@ contract("DepositBox", ([deployer, user, user2]) => {
 
       await initializeSchain(contractManager, schainID, deployer, 1, 1);
       await setCommonPublicKey(contractManager, schainID);
-      await rechargeSchainWallet(contractManager, schainID, "1000000000000000000");
+      await rechargeSchainWallet(contractManager, schainID, deployer, "1000000000000000000");
       // add schain to avoid the `Unconnected chain` error
       await imaLinker
         .connectSchain(schainID, [deployer, deployer, deployer], {from: deployer});
@@ -574,7 +574,7 @@ contract("DepositBox", ([deployer, user, user2]) => {
 
       await initializeSchain(contractManager, schainID, user2, 1, 1);
       await setCommonPublicKey(contractManager, schainID);
-      await rechargeSchainWallet(contractManager, schainID, "1000000000000000000");
+      await rechargeSchainWallet(contractManager, schainID, user2, "1000000000000000000");
       // add schain to avoid the `Unconnected chain` error
       await imaLinker
         .connectSchain(schainID, [deployer, deployer, deployer], {from: deployer});

--- a/proxy/test/MessageProxy.ts
+++ b/proxy/test/MessageProxy.ts
@@ -167,7 +167,7 @@ contract("MessageProxy", ([deployer, user, client, customer]) => {
             const startingCounter = 0;
             await initializeSchain(contractManager, chainID, deployer, 1, 1);
             await setCommonPublicKey(contractManager, chainID);
-            await rechargeSchainWallet(contractManager, chainID, "1000000000000000000");
+            await rechargeSchainWallet(contractManager, chainID, deployer, "1000000000000000000");
 
             const message1 = {
                 amount: 3,
@@ -248,7 +248,7 @@ contract("MessageProxy", ([deployer, user, client, customer]) => {
             // tokenManager2 = await TokenManager.new(chainID, lockAndDataForMainnet.address, {from: deployer});
             await initializeSchain(contractManager, chainID, deployer, 1, 1);
             await setCommonPublicKey(contractManager, chainID);
-            await rechargeSchainWallet(contractManager, chainID, "1000000000000000000");
+            await rechargeSchainWallet(contractManager, chainID, deployer, "1000000000000000000");
             const startingCounter = 0;
             const message1 = {
                 amount: 3,
@@ -320,7 +320,7 @@ contract("MessageProxy", ([deployer, user, client, customer]) => {
             // tokenManager2 = await TokenManager.new(chainID, lockAndDataForMainnet.address, {from: deployer});
             await initializeSchain(contractManager, chainID, deployer, 1, 1);
             await setCommonPublicKey(contractManager, chainID);
-            await rechargeSchainWallet(contractManager, chainID, "1000000000000000000");
+            await rechargeSchainWallet(contractManager, chainID, deployer, "1000000000000000000");
             const startingCounter = 0;
             const message1 = {
                 amount: 3,

--- a/proxy/test/TokenManager.spec.ts
+++ b/proxy/test/TokenManager.spec.ts
@@ -358,6 +358,7 @@ contract("TokenManager", ([deployer, user, client]) => {
         const error = "Not allowed ERC721 Token";
         const amountToCost = "9000000000000000";
         const tokenId = 10;
+        const tokenId2 = 11;
         // set contract TokenManager to avoid `Not allowed` exception on `exitToMainERC20` function:
         await lockAndDataForSchain.setContract("TokenManager", tokenManager.address, {from: deployer});
         // set contract ERC20ModuleForSchain to avoid `revert` exception on `exitToMainERC20` function:
@@ -370,12 +371,13 @@ contract("TokenManager", ([deployer, user, client]) => {
         await lockAndDataForSchain.setContract(
             "MessageProxyForSchain", messageProxyForSchain.address, {from: deployer});
         // add connected chain:
-        await lockAndDataForSchainERC721.addERC721ForSchain("Mainnet", eRC20.address,eRC20OnChain.address, {from: deployer});
+        await lockAndDataForSchainERC721.addERC721ForSchain("Mainnet", eRC20.address, eRC20OnChain.address, {from: deployer});
         // invoke `grantRole` before `sendERC721` to avoid `MinterRole: caller does not have the Minter role`  exception
         const minterRole = await eRC721OnChain.MINTER_ROLE();
         await eRC721OnChain.grantRole(minterRole, lockAndDataForSchainERC721.address);
         // invoke `mint` to avoid `SafeMath: subtraction overflow` exception on `exitToMainERC20` function:
         await eRC721OnChain.mint(deployer, tokenId, {from: deployer});
+        await eRC721OnChain.mint(deployer, tokenId2, {from: deployer});
         // invoke `addERC20ForSchain` to avoid `Not existing ERC-20 contract` exception on `exitToMainERC20` function:
         await lockAndDataForSchainERC721.addERC721ForSchain("Mainnet", eRC721.address, eRC721OnChain.address, {from: deployer});
         // invoke `approve` to avoid `Not allowed ERC20 Token` exception on `exitToMainERC20` function:
@@ -383,7 +385,7 @@ contract("TokenManager", ([deployer, user, client]) => {
 
         // execution:
         await tokenManager
-            .exitToMainERC721(eRC721.address, client, tokenId, {from: deployer})
+            .exitToMainERC721(eRC721.address, client, tokenId2, {from: deployer})
             .should.be.eventually.rejectedWith(error);
     });
 
@@ -416,7 +418,7 @@ contract("TokenManager", ([deployer, user, client]) => {
         await eRC721OnChain.mint(user, tokenId, {from: deployer});
         // invoke `addExit` to avoid `Does not allow to exit` exception on `exitToMainERC20` function:
         await lockAndDataForSchain.sendEth(user, amountEth, {from: deployer});
-        await eRC721OnChain.transferFrom(user, tokenManager.address, tokenId, {from: user});
+        await eRC721OnChain.approve(tokenManager.address, tokenId, {from: user});
 
         // execution:
         await tokenManager.exitToMainERC721(contractThere, to, tokenId, {from: user});
@@ -455,7 +457,7 @@ contract("TokenManager", ([deployer, user, client]) => {
         // invoke `mint` to avoid `SafeMath: subtraction overflow` exception on `exitToMainERC20` function:
         await eRC721OnChain.mint(deployer, tokenId, {from: deployer});
 
-        await eRC721OnChain.transferFrom(deployer, tokenManager.address, tokenId, {from: deployer});
+        await eRC721OnChain.approve(tokenManager.address, tokenId, {from: deployer});
 
         // execution:
         const res = await tokenManager
@@ -470,11 +472,13 @@ contract("TokenManager", ([deployer, user, client]) => {
         const error = "Not allowed ERC721 Token";
         const amountToCost = "9000000000000000";
         const tokenId = 10;
+        const tokenId2 = 11;
         const contractHere = eRC721OnChain.address;
         const contractThere = eRC721.address;
         const to = user;
         const schainID = randomString(10);
         await lockAndDataForSchain.addSchain(schainID, tokenManager.address, {from: deployer});
+        await messageProxyForSchain.addConnectedChain(schainID, [0,0,0,0], {from: deployer})
         // set contract TokenManager to avoid `Not allowed` exception on `exitToMainERC20` function:
         await lockAndDataForSchain.setContract("TokenManager", tokenManager.address, {from: deployer});
         // set contract ERC20ModuleForSchain to avoid `revert` exception on `exitToMainERC20` function:
@@ -494,6 +498,7 @@ contract("TokenManager", ([deployer, user, client]) => {
         await eRC721OnChain.grantRole(minterRole, lockAndDataForSchainERC721.address);
         // invoke `mint` to avoid `SafeMath: subtraction overflow` exception on `exitToMainERC20` function:
         await eRC721OnChain.mint(deployer, tokenId, {from: deployer});
+        await eRC721OnChain.mint(deployer, tokenId2, {from: deployer});
         // invoke `addERC20ForSchain` to avoid `Not existing ERC-20 contract` exception on `exitToMainERC20` function:
         await lockAndDataForSchainERC721.addERC721ForSchain(schainID, eRC721.address, eRC721OnChain.address, {from: deployer});
         // invoke `approve` to avoid `Not allowed ERC20 Token` exception on `exitToMainERC20` function:
@@ -501,7 +506,7 @@ contract("TokenManager", ([deployer, user, client]) => {
 
         // execution:
         await tokenManager
-            .transferToSchainERC721(schainID, contractThere, to, tokenId, {from: deployer})
+            .transferToSchainERC721(schainID, contractThere, to, tokenId2, {from: deployer})
             .should.be.eventually.rejectedWith(error);
     });
 

--- a/proxy/test/utils/skale-manager-utils/wallets.ts
+++ b/proxy/test/utils/skale-manager-utils/wallets.ts
@@ -22,7 +22,7 @@ export async function rechargeSchainWallet(
     }
 
     const schainActive = await isSchainActive(contractManager, schainName);
-    if (!schainActive) 
+    if ( !schainActive )
         await initializeSchain(contractManager, schainName, owner, 1, 1);
 
     await walletsInstance.rechargeSchainWallet(web3.utils.soliditySha3(schainName), {value: amountEth /*"1000000000000000000"*/});

--- a/proxy/test/utils/skale-manager-utils/wallets.ts
+++ b/proxy/test/utils/skale-manager-utils/wallets.ts
@@ -1,5 +1,6 @@
 import { ContractManagerInstance } from "../../../types/truffle-contracts";
 import { WalletsContract, WalletsInstance } from "../../../types/truffle-contracts";
+import { initializeSchain, isSchainActive } from "./schainsInternal";
 
 const wallets: WalletsContract = artifacts.require("./Wallets");
 const nameWallets = "Wallets";
@@ -7,6 +8,7 @@ const nameWallets = "Wallets";
 export async function rechargeSchainWallet(
     contractManager: ContractManagerInstance,
     schainName: string,
+    owner: string,
     amountEth: string
 ) {
     let walletsInstance: WalletsInstance;
@@ -18,6 +20,10 @@ export async function rechargeSchainWallet(
     } else {
         walletsInstance = await wallets.at(await contractManager.getContract(nameWallets));
     }
+
+    const schainActive = await isSchainActive(contractManager, schainName);
+    if (!schainActive) 
+        await initializeSchain(contractManager, schainName, owner, 1, 1);
 
     await walletsInstance.rechargeSchainWallet(web3.utils.soliditySha3(schainName), {value: amountEth /*"1000000000000000000"*/});
 }

--- a/proxy/test/utils/skale-manager-utils/wallets.ts
+++ b/proxy/test/utils/skale-manager-utils/wallets.ts
@@ -25,5 +25,6 @@ export async function rechargeSchainWallet(
     if ( !schainActive )
         await initializeSchain(contractManager, schainName, owner, 1, 1);
 
-    await walletsInstance.rechargeSchainWallet(web3.utils.soliditySha3(schainName), {value: amountEth /*"1000000000000000000"*/});
+    const schainId = await web3.utils.soliditySha3(schainName);
+    await walletsInstance.rechargeSchainWallet(schainId, {value: amountEth /*"1000000000000000000"*/});
 }


### PR DESCRIPTION
Change transferFrom to approve in ERC721 flow

Use `approve` and `getApproved` functions from [ERC721 standard](https://eips.ethereum.org/EIPS/eip-721).

We could not support CryptoKitties in depositBoxERC721 - `kittyIndexToApproved` instead of `getApproved`

For CryptoKitties we could create additional registry contract and connect it to MessageProxy