### PR TITLE
SKALE-4134 implemented monitoring ws rpc server

### DIFF
--- a/agent/cli.js
+++ b/agent/cli.js
@@ -326,6 +326,9 @@ function parse( joExternalHandlers, argv ) {
             console.log( soi + cc.debug( "--" ) + cc.bright( "hash-g1" ) + cc.sunny( "=" ) + cc.note( "path" ) + cc.debug( ".................." ) + cc.notice( "Specifies path to " ) + cc.note( "hash_g1" ) + cc.note( " application" ) + cc.notice( "." ) );
             console.log( soi + cc.debug( "--" ) + cc.bright( "bls-verify" ) + cc.sunny( "=" ) + cc.note( "path" ) + cc.debug( "..............." ) + cc.notice( "Optional parameter, specifies path to " ) + cc.note( "verify_bls" ) + cc.note( " application" ) + cc.notice( "." ) );
             //
+            console.log( cc.sunny( "MONITORING" ) + cc.info( " options:" ) );
+            console.log( soi + cc.debug( "--" ) + cc.bright( "monitoring-port" ) + cc.sunny( "=" ) + cc.note( "number" ) + cc.debug( "........" ) + cc.notice( "Run monitoring web socket RPC server on specified port. By default monitoring server is disabled." ) );
+            //
             console.log( cc.sunny( "TEST" ) + cc.info( " options:" ) );
             console.log( soi + cc.debug( "--" ) + cc.bright( "browse-s-chain" ) + cc.debug( "................" ) + cc.notice( "Download S-Chain network information." ) );
             //
@@ -811,6 +814,11 @@ function parse( joExternalHandlers, argv ) {
         if( joArg.name == "bls-verify" ) {
             owaspUtils.verifyArgumentIsPathToExistingFile( joArg );
             imaState.strPathBlsVerify = "" + joArg.value;
+            continue;
+        }
+        if( joArg.name == "monitoring-port" ) {
+            owaspUtils.verifyArgumentIsIntegerIpPortNumber( joArg );
+            imaState.nMonitoringPort = owaspUtils.toInteger( joArg.value );
             continue;
         }
         if( joArg.name == "register" ||

--- a/agent/main.js
+++ b/agent/main.js
@@ -931,7 +931,7 @@ if( imaState.nMonitoringPort > 0 ) {
                     } break;
                 case "get_last_transfer_errors":
                     // call:   { "id": 1, "method": "get_last_transfer_errors" }
-                    // answer: { "id": 1, "method": "get_last_transfer_errors", "error": null, "last_transfer_errors": ... }
+                    // answer: { "id": 1, "method": "get_last_transfer_errors", "error": null, "last_transfer_errors": [ { ts: ..., textLog: ... }, ... ] }
                     joAnswer.last_transfer_errors = IMA.get_last_transfer_errors();
                     break;
                 default:

--- a/agent/run.sh
+++ b/agent/run.sh
@@ -17,6 +17,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 : "${NODE_NUMBER?Need to set NODE_NUMBER}"
 : "${NODES_COUNT?Need to set NODES_COUNT}"
 
+: "${MONITORING_PORT?Need to set MONITORING_PORT}"
+
 : "${TM_URL_MAIN_NET?Need to set TM_URL_MAIN_NET}"
 
 # SGX variables
@@ -91,7 +93,8 @@ BASE_OPTIONS="--gas-price-multiplier=$GAS_PRICE_MULTIPLIER \
     --nodes-count=$NODES_COUNT \
     --time-framing=$TIME_FRAMING \
     --tm-url-main-net=$TM_URL_MAIN_NET \
-    --time-gap=$TIME_GAP"
+    --time-gap=$TIME_GAP \
+    --monitoring-port=$MONITORING_PORT"
 
 echo "Base options:"
 echo "$BASE_OPTIONS"

--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -2652,6 +2652,24 @@ async function async_pending_tx_scanner( details, w3, w3_opposite, chain_id, cha
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const g_nMaxLastTransferErrors = 10;
+const g_arrLastTransferErrors = [];
+
+function save_transfer_error( textLog ) {
+    const ts = Math.round( ( new Date() ).getTime() / 1000 );
+    g_arrLastTransferErrors.push( {
+        ts: ts,
+        textLog: "" + textLog.toString()
+    } );
+    while( g_arrLastTransferErrors.length > g_nMaxLastTransferErrors )
+        g_arrLastTransferErrors.shift();
+}
+
+function get_last_transfer_errors( textLog ) {
+    return JSON.parse( JSON.stringify( g_arrLastTransferErrors ) );
+}
+
 //
 // Do real money movement from main-net to S-chain by sniffing events
 // 1) main-net.MessageProxyForMainnet.getOutgoingMessagesCounter -> save to nOutMsgCnt
@@ -2821,6 +2839,7 @@ async function do_transfer(
                     log.write( strLogPrefix + cc.fatal( "CRITICAL ERROR:" ) + " " + cc.error( "Can't get events from MessageProxy" ) + "\n" );
                     details.write( strLogPrefix + cc.fatal( "CRITICAL ERROR:" ) + " " + cc.error( "Can't get events from MessageProxy" ) + "\n" );
                     details.exposeDetailsTo( log, "do_transfer", false );
+                    save_transfer_error( details.toString() );
                     details.close();
                     return; // process.exit( 126 );
                 }
@@ -2849,6 +2868,7 @@ async function do_transfer(
                             log.write( s );
                         details.write( s );
                         details.exposeDetailsTo( log, "do_transfer", false );
+                        save_transfer_error( details.toString() );
                         details.close();
                         return false;
                     }
@@ -2892,6 +2912,7 @@ async function do_transfer(
                             log.write( s );
                         details.write( s );
                         details.exposeDetailsTo( log, "do_transfer", false );
+                        save_transfer_error( details.toString() );
                         details.close();
                         return false;
                     }
@@ -3045,6 +3066,7 @@ async function do_transfer(
                         log.write( s );
                     details.write( s );
                     details.exposeDetailsTo( log, "do_transfer", false );
+                    save_transfer_error( details.toString() );
                     details.close();
                     return;
                 }
@@ -3251,6 +3273,7 @@ async function do_transfer(
             log.write( strLogPrefix + cc.fatal( "CRITICAL ERROR:" ) + cc.error( " Error in do_transfer() during " + strActionName + ": " ) + cc.error( err ) + "\n" );
         details.write( strLogPrefix + cc.fatal( "CRITICAL ERROR:" ) + cc.error( " Error in do_transfer() during " + strActionName + ": " ) + cc.error( err ) + "\n" );
         details.exposeDetailsTo( log, "do_transfer", false );
+        save_transfer_error( details.toString() );
         details.close();
         return false;
     }
@@ -3397,6 +3420,8 @@ module.exports.do_erc20_payment_from_main_net = do_erc20_payment_from_main_net;
 module.exports.do_erc20_payment_from_s_chain = do_erc20_payment_from_s_chain;
 module.exports.do_erc721_payment_from_s_chain = do_erc721_payment_from_s_chain;
 module.exports.do_transfer = do_transfer;
+module.exports.save_transfer_error = save_transfer_error;
+module.exports.get_last_transfer_errors = get_last_transfer_errors;
 
 module.exports.compose_gas_usage_report_from_array = compose_gas_usage_report_from_array;
 module.exports.print_gas_usage_report_from_array = print_gas_usage_report_from_array;

--- a/npms/skale-owasp/owasp-util.js
+++ b/npms/skale-owasp/owasp-util.js
@@ -282,6 +282,21 @@ function verifyArgumentIsInteger( joArg ) {
     }
 }
 
+function verifyArgumentIsIntegerIpPortNumber( joArg ) {
+    try {
+        verifyArgumentIsInteger( joArg );
+        if( joArg.value < 0 )
+            throw new Error( "Port number " + joArg.value + " cannot be negative" );
+        if( joArg.value < 1 )
+            throw new Error( "Port number " + joArg.value + " too small" );
+        if( joArg.value > 65535 )
+            throw new Error( "Port number " + joArg.value + " too big" );
+    } catch ( err ) {
+        console.log( cc.fatal( "(OWASP) CRITICAL ERROR:" ) + cc.error( " value " ) + cc.warning( joArg.value ) + cc.error( " of argument " ) + cc.info( joArg.name ) + cc.error( " must be valid integer IP port number" ) );
+        process.exit( 126 );
+    }
+}
+
 function verifyArgumentIsPathToExistingFile( joArg ) {
     try {
         verifyArgumentWithNonEmptyValue( joArg );
@@ -536,6 +551,7 @@ module.exports = {
     verifyArgumentWithNonEmptyValue: verifyArgumentWithNonEmptyValue,
     verifyArgumentIsURL: verifyArgumentIsURL,
     verifyArgumentIsInteger: verifyArgumentIsInteger,
+    verifyArgumentIsIntegerIpPortNumber: verifyArgumentIsIntegerIpPortNumber,
     verifyArgumentIsPathToExistingFile: verifyArgumentIsPathToExistingFile,
     verifyArgumentIsPathToExistingFolder: verifyArgumentIsPathToExistingFolder,
     ensure_starts_with_0x: ensure_starts_with_0x,


### PR DESCRIPTION
New optional web socket server exposes JSON RPC with for monitoring purposes. Supported calls:
```
call:   { "id": 1, "method": "echo" }
answer: { "id": 1, "method": "echo", "error": null }

call:   { "id": 1, "method": "ping" }
answer: { "id": 1, "method": "ping", "error": null }

call:   { "id": 1, "method": "get_schain_network_info" }
answer: { "id": 1, "method": "get_schain_network_info", "error": null, "schain_network_info": ... }

call:   { "id": 1, "method": "get_runtime_params" }
answer: { "id": 1, "method": "get_runtime_params", "error": null, "runtime_params": ... }

call:   { "id": 1, "method": "get_last_transfer_errors" }
answer: { "id": 1, "method": "get_last_transfer_errors", "error": null, "last_transfer_errors": [ { ts: ..., textLog: ... }, ... ] }
``` 
IMA agent accumulates up to 10 recent transfer errors. They are available via call to `get_last_transfer_errors`.