### PR TITLE
SKALE-4192 postIncommingMessages uses it's own log accumulator

### DIFF
--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -3058,6 +3058,7 @@ async function do_transfer(
             //
             strActionName = "sign messages";
             await fn_sign_messages( messages, nIdxCurrentMsgBlockStart, details, async function( err, jarrMessages, joGlueResult ) {
+                const details = log.createMemoryStream();
                 if( err ) {
                     bErrorInSigningMessages = true;
                     const s = strLogPrefix + cc.fatal( "CRITICAL ERROR:" ) + cc.error( " Error signing messages: " ) + cc.error( err ) + "\n";
@@ -3237,6 +3238,9 @@ async function do_transfer(
                 //
                 //
                 //
+                if( expose_details_get() )
+                    details.exposeDetailsTo( log, "do_transfer", true );
+                details.close();
             } );
             if( bErrorInSigningMessages )
                 break;


### PR DESCRIPTION
- `postIncommingMessages` call uses it's own log accumulator
- no new tests needed