### PR TITLE
enable contract deposit box usage via destination address

### DIFF
--- a/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC1155.sol
+++ b/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC1155.sol
@@ -106,6 +106,44 @@ contract DepositBoxERC1155 is DepositBox, ERC1155ReceiverUpgradeable, IDepositBo
         rightTransaction(schainName, msg.sender)
         whenNotKilled(keccak256(abi.encodePacked(schainName)))
     {
+        _depositTransferERC1155(schainName, erc1155OnMainnet, msg.sender, id, amount);
+    }
+
+    /**
+     * @dev Allows `msg.sender` to send ERC1155 token from mainnet to a specific schain destination address.
+     * This is potentially dangerous if the destination address is invalid.
+     * Consider depositERC1155() instead.
+     * 
+     * Requirements:
+     * 
+     * - Receiver contract should be defined.
+     * - `msg.sender` should approve their tokens for DepositBoxERC1155 address.
+     * - destination `to` cannot be 0 address.
+     */
+    function transferERC1155(
+        string calldata schainName,
+        address erc1155OnMainnet,
+        address to,
+        uint256 id,
+        uint256 amount
+    )
+        external
+        override
+        rightTransaction(schainName, to)
+        whenNotKilled(keccak256(abi.encodePacked(schainName)))
+    {
+        _depositTransferERC1155(schainName, erc1155OnMainnet, to, id, amount);
+    }
+
+    function _depositTransferERC1155(
+        string calldata schainName,
+        address erc1155OnMainnet,
+        address to,
+        uint256 id,
+        uint256 amount
+    )
+        private
+    {
         bytes32 schainHash = keccak256(abi.encodePacked(schainName));
         address contractReceiver = schainLinks[schainHash];
         require(contractReceiver != address(0), "Unconnected chain");
@@ -116,7 +154,7 @@ contract DepositBoxERC1155 is DepositBox, ERC1155ReceiverUpgradeable, IDepositBo
         bytes memory data = _receiveERC1155(
             schainName,
             erc1155OnMainnet,
-            msg.sender,
+            to,
             id,
             amount
         );
@@ -149,6 +187,50 @@ contract DepositBoxERC1155 is DepositBox, ERC1155ReceiverUpgradeable, IDepositBo
         rightTransaction(schainName, msg.sender)
         whenNotKilled(keccak256(abi.encodePacked(schainName)))
     {
+        _depositERC1155Batch(schainName, erc1155OnMainnet, msg.sender, ids, amounts);
+    }
+
+    /**
+     * @dev Allows `msg.sender` to send batch of ERC1155 tokens from mainnet to a specific schain destination address.
+     * 
+     * Requirements:
+     * 
+     * - Receiver contract should be defined.
+     * - `msg.sender` should approve their tokens for DepositBoxERC1155 address.
+     * - destination `to` cannot be 0 address.
+     */
+    function transferERC1155Batch(
+        string calldata schainName,
+        address erc1155OnMainnet,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata amounts
+    )
+        external
+        override
+        rightTransaction(schainName, to)
+        whenNotKilled(keccak256(abi.encodePacked(schainName)))
+    {
+        _depositERC1155Batch(schainName, erc1155OnMainnet, to, ids, amounts);
+    }
+
+    /**
+     * @dev Allows `msg.sender` to send batch of ERC1155 tokens from mainnet to schain.
+     * 
+     * Requirements:
+     * 
+     * - Receiver contract should be defined.
+     * - `msg.sender` should approve their tokens for DepositBoxERC1155 address.
+     */
+    function _depositTransferERC1155Batch(
+        string calldata schainName,
+        address erc1155OnMainnet,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata amounts
+    )
+        private
+    {
         bytes32 schainHash = keccak256(abi.encodePacked(schainName));
         address contractReceiver = schainLinks[schainHash];
         require(contractReceiver != address(0), "Unconnected chain");
@@ -159,7 +241,7 @@ contract DepositBoxERC1155 is DepositBox, ERC1155ReceiverUpgradeable, IDepositBo
         bytes memory data = _receiveERC1155Batch(
             schainName,
             erc1155OnMainnet,
-            msg.sender,
+            to,
             ids,
             amounts
         );

--- a/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
+++ b/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
@@ -102,6 +102,45 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
         rightTransaction(schainName, msg.sender)
         whenNotKilled(keccak256(abi.encodePacked(schainName)))
     {
+        _depositTransferERC20(schainName, erc20OnMainnet, msg.sender, amount);
+    }
+
+    /**
+     * @dev Allows `msg.sender` to send ERC20 token from mainnet to a specific schain destination address.
+     * This is potentially dangerous if the destination address is invalid.
+     * Consider depositERC20() instead.
+     * 
+     * Requirements:
+     * 
+     * - Schain name must not be `Mainnet`.
+     * - Receiver account on schain cannot be null.
+     * - Schain that receives tokens should not be killed.
+     * - Receiver contract should be defined.
+     * - destination {to} cannot be 0 address.
+     * - `msg.sender` should approve their tokens for DepositBoxERC20 address.
+     */
+    function transferERC20(
+        string calldata schainName,
+        address erc20OnMainnet,
+        address to,
+        uint256 amount
+    )
+        external
+        override
+        rightTransaction(schainName, to)
+        whenNotKilled(keccak256(abi.encodePacked(schainName)))
+    {
+        _depositTransferERC20(schainName, erc20OnMainnet, to, amount);
+    }
+
+    function _depositTransferERC20(
+        string calldata schainName,
+        address erc20OnMainnet,
+        address to,
+        uint256 amount
+    )
+        private
+    {
         bytes32 schainHash = keccak256(abi.encodePacked(schainName));
         address contractReceiver = schainLinks[schainHash];
         require(contractReceiver != address(0), "Unconnected chain");
@@ -112,7 +151,7 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
         bytes memory data = _receiveERC20(
             schainName,
             erc20OnMainnet,
-            msg.sender,
+            to,
             amount
         );
         if (!linker.interchainConnections(schainHash))

--- a/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC721.sol
+++ b/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC721.sol
@@ -99,6 +99,42 @@ contract DepositBoxERC721 is DepositBox, IDepositBoxERC721 {
         rightTransaction(schainName, msg.sender)
         whenNotKilled(keccak256(abi.encodePacked(schainName)))
     {
+        _depositTransferERC721(schainName, erc721OnMainnet, msg.sender, tokenId);
+    }
+
+    /**
+     * @dev Allows `msg.sender` to send ERC721 token from mainnet to a specific schain destination address.
+     * This is potentially dangerous if the destination address is invalid.
+     * Consider depositERC721() instead.
+     * 
+     * Requirements:
+     * 
+     * - Receiver contract should be defined.
+     * - `msg.sender` should approve their token for DepositBoxERC721 address.
+     * - destination `to` cannot be 0 address.
+     */
+    function transferERC721(
+        string calldata schainName,
+        address erc721OnMainnet,
+        address to,
+        uint256 tokenId
+    )
+        external
+        override
+        rightTransaction(schainName, to)
+        whenNotKilled(keccak256(abi.encodePacked(schainName)))
+    {
+        _depositTransferERC721(schainName, erc721OnMainnet, to, tokenId);
+    }
+
+    function _depositTransferERC721(
+        string calldata schainName,
+        address erc721OnMainnet,
+        address to,
+        uint256 tokenId
+    )
+        private
+    {
         bytes32 schainHash = keccak256(abi.encodePacked(schainName));
         address contractReceiver = schainLinks[schainHash];
         require(contractReceiver != address(0), "Unconnected chain");
@@ -109,7 +145,7 @@ contract DepositBoxERC721 is DepositBox, IDepositBoxERC721 {
         bytes memory data = _receiveERC721(
             schainName,
             erc721OnMainnet,
-            msg.sender,
+            to,
             tokenId
         );
         if (!linker.interchainConnections(schainHash))

--- a/proxy/contracts/schain/TokenManagers/TokenManagerERC1155.sol
+++ b/proxy/contracts/schain/TokenManagers/TokenManagerERC1155.sol
@@ -69,7 +69,7 @@ contract TokenManagerERC1155 is TokenManager, ITokenManagerERC1155 {
     /**
      * @dev Move tokens from schain to mainnet.
      * 
-     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for {to} address.
+     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for same sender address.
      */
     function exitToMainERC1155(
         address contractOnMainnet,
@@ -84,9 +84,28 @@ contract TokenManagerERC1155 is TokenManager, ITokenManagerERC1155 {
     }
 
     /**
-     * @dev Move batch of tokens from schain to mainnet.
+     * @dev Move tokens from schain to mainnet.
      * 
      * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for {to} address.
+     */
+    function exitToMainERC1155(
+        address contractOnMainnet,
+        address to,
+        uint256 id,
+        uint256 amount
+    )
+        external
+        override
+    {
+        require(to != address(0), "Destination cannot be 0 address");
+        communityLocker.checkAllowedToSendMessage(msg.sender);
+        _exit(MAINNET_HASH, depositBox, contractOnMainnet, to, id, amount);
+    }
+
+    /**
+     * @dev Move batch of tokens from schain to mainnet.
+     * 
+     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for same address as sender.
      */
     function exitToMainERC1155Batch(
         address contractOnMainnet,
@@ -98,6 +117,25 @@ contract TokenManagerERC1155 is TokenManager, ITokenManagerERC1155 {
     {
         communityLocker.checkAllowedToSendMessage(msg.sender);
         _exitBatch(MAINNET_HASH, depositBox, contractOnMainnet, msg.sender, ids, amounts);
+    }
+
+    /**
+     * @dev Move batch of tokens from schain to mainnet.
+     * 
+     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for {to} address.
+     */
+    function exitToMainERC1155Batch(
+        address contractOnMainnet,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts
+    )
+        external
+        override
+    {
+        require(to != address(0), "Destination cannot be 0 address");
+        communityLocker.checkAllowedToSendMessage(msg.sender);
+        _exitBatch(MAINNET_HASH, depositBox, contractOnMainnet, to, ids, amounts);
     }
 
     /**
@@ -121,6 +159,27 @@ contract TokenManagerERC1155 is TokenManager, ITokenManagerERC1155 {
     }
 
     /**
+     * @dev Move tokens from schain to schain.
+     * 
+     * {contractOnMainnet} tokens are burned on origin schain
+     * and are minted on {targetSchainName} schain for {to} address.
+     */
+    function transferToSchainERC1155(
+        string calldata targetSchainName,
+        address contractOnMainnet,
+        address to,
+        uint256 id,
+        uint256 amount
+    ) 
+        external
+        override
+        rightTransaction(targetSchainName, to)
+    {
+        bytes32 targetSchainHash = keccak256(abi.encodePacked(targetSchainName));
+        _exit(targetSchainHash, tokenManagers[targetSchainHash], contractOnMainnet, to, id, amount);
+    }
+
+    /**
      * @dev Move batch of tokens from schain to schain.
      * 
      * {contractOnMainnet} tokens are burned on origin schain
@@ -138,6 +197,27 @@ contract TokenManagerERC1155 is TokenManager, ITokenManagerERC1155 {
     {
         bytes32 targetSchainHash = keccak256(abi.encodePacked(targetSchainName));
         _exitBatch(targetSchainHash, tokenManagers[targetSchainHash], contractOnMainnet, msg.sender, ids, amounts);
+    }
+
+    /**
+     * @dev Move batch of tokens from schain to schain.
+     * 
+     * {contractOnMainnet} tokens are burned on origin schain
+     * and are minted on {targetSchainName} schain for {to} address.
+     */
+    function transferToSchainERC1155Batch(
+        string calldata targetSchainName,
+        address contractOnMainnet,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts
+    ) 
+        external
+        override
+        rightTransaction(targetSchainName, to)
+    {
+        bytes32 targetSchainHash = keccak256(abi.encodePacked(targetSchainName));
+        _exitBatch(targetSchainHash, tokenManagers[targetSchainHash], contractOnMainnet, to, ids, amounts);
     }
 
     /**

--- a/proxy/contracts/schain/TokenManagers/TokenManagerERC20.sol
+++ b/proxy/contracts/schain/TokenManagers/TokenManagerERC20.sol
@@ -68,7 +68,7 @@ contract TokenManagerERC20 is TokenManager, ITokenManagerERC20 {
     /**
      * @dev Move tokens from schain to mainnet.
      * 
-     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for {to} address.
+     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for same address as sender.
      */
     function exitToMainERC20(
         address contractOnMainnet,
@@ -79,6 +79,25 @@ contract TokenManagerERC20 is TokenManager, ITokenManagerERC20 {
     {
         communityLocker.checkAllowedToSendMessage(msg.sender);
         _exit(MAINNET_HASH, depositBox, contractOnMainnet, msg.sender, amount);
+    }
+
+    /**
+     * @dev Move tokens from schain to mainnet.
+     * 
+     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for {to} address.
+     * - destination `to` cannot be 0 address.
+     */
+    function exitToMainERC20(
+        address contractOnMainnet,
+        address to,
+        uint256 amount
+    )
+        external
+        override
+    {
+        require(to != address(0), "Destination cannot be 0 address");
+        communityLocker.checkAllowedToSendMessage(msg.sender);
+        _exit(MAINNET_HASH, depositBox, contractOnMainnet, to, amount);
     }
 
     /**
@@ -98,6 +117,27 @@ contract TokenManagerERC20 is TokenManager, ITokenManagerERC20 {
     {
         bytes32 targetSchainHash = keccak256(abi.encodePacked(targetSchainName));
         _exit(targetSchainHash, tokenManagers[targetSchainHash], contractOnMainnet, msg.sender, amount);
+    }
+
+    /**
+     * @dev Move tokens from schain to schain.
+     * 
+     * {contractOnMainnet} tokens are burned on origin schain
+     * and are minted on {targetSchainName} schain for `to` address.
+     * - destination `to` cannot be 0 address.
+     */
+    function transferToSchainERC20(
+        string calldata targetSchainName,
+        address contractOnMainnet,
+        address to,
+        uint256 amount
+    )
+        external
+        override
+        rightTransaction(targetSchainName, to)
+    {
+        bytes32 targetSchainHash = keccak256(abi.encodePacked(targetSchainName));
+        _exit(targetSchainHash, tokenManagers[targetSchainHash], contractOnMainnet, to, amount);
     }
 
     /**

--- a/proxy/contracts/schain/TokenManagers/TokenManagerERC721.sol
+++ b/proxy/contracts/schain/TokenManagers/TokenManagerERC721.sol
@@ -63,7 +63,7 @@ contract TokenManagerERC721 is TokenManager, ITokenManagerERC721 {
     /**
      * @dev Move tokens from schain to mainnet.
      * 
-     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for {to} address.
+     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for same address as sender.
      */
     function exitToMainERC721(
         address contractOnMainnet,
@@ -74,6 +74,24 @@ contract TokenManagerERC721 is TokenManager, ITokenManagerERC721 {
     {
         communityLocker.checkAllowedToSendMessage(msg.sender);
         _exit(MAINNET_HASH, depositBox, contractOnMainnet, msg.sender, tokenId);
+    }
+
+    /**
+     * @dev Move tokens from schain to mainnet.
+     * 
+     * {contractOnMainnet} tokens are burned on schain and unlocked on mainnet for `to` address.
+     */
+    function exitToMainERC721(
+        address contractOnMainnet,
+        address to,
+        uint256 tokenId
+    )
+        external
+        override
+    {
+        require(to != address(0), "Destination cannot be 0 address");
+        communityLocker.checkAllowedToSendMessage(msg.sender);
+        _exit(MAINNET_HASH, depositBox, contractOnMainnet, to, tokenId);
     }
 
     /**
@@ -93,6 +111,26 @@ contract TokenManagerERC721 is TokenManager, ITokenManagerERC721 {
     {
         bytes32 targetSchainHash = keccak256(abi.encodePacked(targetSchainName));
         _exit(targetSchainHash, tokenManagers[targetSchainHash], contractOnMainnet, msg.sender, tokenId);
+    }
+
+    /**
+     * @dev Move tokens from schain to schain.
+     * 
+     * {contractOnMainnet} tokens are burned on origin schain
+     * and are minted on {targetSchainName} schain for {to} address.
+     */
+    function transferToSchainERC721(
+        string calldata targetSchainName,
+        address contractOnMainnet,
+        address to,
+        uint256 tokenId
+    ) 
+        external
+        override
+        rightTransaction(targetSchainName, to)
+    {
+        bytes32 targetSchainHash = keccak256(abi.encodePacked(targetSchainName));
+        _exit(targetSchainHash, tokenManagers[targetSchainHash], contractOnMainnet, to, tokenId);
     }
 
     /**

--- a/proxy/contracts/schain/TokenManagers/TokenManagerEth.sol
+++ b/proxy/contracts/schain/TokenManagers/TokenManagerEth.sol
@@ -59,10 +59,21 @@ contract TokenManagerEth is TokenManager, ITokenManagerEth {
     }
 
     /**
+     * @dev Move ETH from schain to specific mainnet address.
+     * 
+     * EthErc20 tokens are burned on schain and ETH are unlocked on mainnet for `to` address.
+     */
+    function exitToMain(address to, uint256 amount) external override {
+        require(to != address(0), "Incorrect receiver address");
+        communityLocker.checkAllowedToSendMessage(msg.sender);
+        _exit(MAINNET_HASH, depositBox, to, amount);
+    }
+
+    /**
      * @dev Move ETH from schain to schain.
      * 
      * EthErc20 tokens are burned on origin schain.
-     * and are minted on {targetSchainName} schain for {to} address.
+     * and are minted on {targetSchainName} schain for same sender address.
      */
     function transferToSchain(
         string memory targetSchainName,
@@ -74,6 +85,25 @@ contract TokenManagerEth is TokenManager, ITokenManagerEth {
     {
         bytes32 targetSchainHash = keccak256(abi.encodePacked(targetSchainName));
         _exit(targetSchainHash, tokenManagers[targetSchainHash], msg.sender, amount);
+    }
+
+    /**
+     * @dev Move ETH from schain to specific schain destination address.
+     * 
+     * EthErc20 tokens are burned on origin schain.
+     * and are minted on {targetSchainName} schain for {to} address.
+     */
+    function transferToSchain(
+        string memory targetSchainName,
+        address to,
+        uint256 amount
+    )
+        external
+        override
+        rightTransaction(targetSchainName, to)
+    {
+        bytes32 targetSchainHash = keccak256(abi.encodePacked(targetSchainName));
+        _exit(targetSchainHash, tokenManagers[targetSchainHash], to, amount);
     }
 
     /**


### PR DESCRIPTION
SKALE IMA currently supports interchain token transfers from external accounts only e.g. users with private keys and not smart contracts.

This pull request includes modifications that enable smart contracts to perform transfers among all chains.

The various DepositBox*.deposit* functions are not designed to be called from a contract since they rely on the destination address being the same as msg.sender.  This modification is backward compatible, keeping the previous interface intact and extending with transfer* functions that explicitly pass the SChain destination address.

This modification will require existing interface definitions e.g.e. IDepositBoxEth, IDepositBoxERC20, ..., ITokenManagerEth, ITokenManagerERC20, ... to be extended with the additional overridden function signatures.  These are defined in a different repository @skalenetwork/ima-interfaces.