### PR TITLE
Enhancement/skale 4985 fix call receiver contract

### DIFF
--- a/proxy/contracts/MessageProxy.sol
+++ b/proxy/contracts/MessageProxy.sol
@@ -537,10 +537,10 @@ abstract contract MessageProxy is AccessControlEnumerableUpgradeable, IMessagePr
         return hash;
     }
 
-    function _getSlice(bytes memory text, uint end) private view returns (bytes memory) {
-        uint end = end < text.length ? end : text.length;
-        bytes memory sliced = new bytes(end);
-        for(uint i = 0; i < end; i++){
+    function _getSlice(bytes memory text, uint end) private pure returns (bytes memory) {
+        uint slicedEnd = end < text.length ? end : text.length;
+        bytes memory sliced = new bytes(slicedEnd);
+        for(uint i = 0; i < slicedEnd; i++){
             sliced[i] = text[i];
         }
         return sliced;    

--- a/proxy/contracts/extensions/ERC721ReferenceMintAndMetadataMainnet.sol
+++ b/proxy/contracts/extensions/ERC721ReferenceMintAndMetadataMainnet.sol
@@ -67,7 +67,6 @@ contract ERC721ReferenceMintAndMetadataMainnet is MessageReceiver, IERC721Refere
         external
         override
         onlyMessageProxy
-        returns (address)
     {
         require(schainHash == keccak256(abi.encodePacked(schainName)), "Incorrect name of schain");
         require(sender == senderContractOnSchain, "Incorrect sender contract");
@@ -81,6 +80,5 @@ contract ERC721ReferenceMintAndMetadataMainnet is MessageReceiver, IERC721Refere
             "Token URI was not set"
         );
         ERC721OnChain(erc721ContractOnMainnet).transferFrom(address(this), to, tokenId);
-        return address(0);
     }
 }

--- a/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC1155.sol
+++ b/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC1155.sol
@@ -190,7 +190,6 @@ contract DepositBoxERC1155 is DepositBox, ERC1155ReceiverUpgradeable, IDepositBo
         onlyMessageProxy
         whenNotKilled(schainHash)
         checkReceiverChain(schainHash, sender)
-        returns (address receiver)
     {
         Messages.MessageType operation = Messages.getMessageType(data);
         if (operation == Messages.MessageType.TRANSFER_ERC1155) {
@@ -209,7 +208,6 @@ contract DepositBoxERC1155 is DepositBox, ERC1155ReceiverUpgradeable, IDepositBo
                 message.amount,
                 ""
             );
-            receiver = message.receiver;
         } else if (operation == Messages.MessageType.TRANSFER_ERC1155_BATCH) {
             Messages.TransferErc1155BatchMessage memory message = Messages.decodeTransferErc1155BatchMessage(data);
             require(message.token.isContract(), "Given address is not a contract");
@@ -221,7 +219,6 @@ contract DepositBoxERC1155 is DepositBox, ERC1155ReceiverUpgradeable, IDepositBo
                 message.amounts,
                 ""
             );
-            receiver = message.receiver;
         }
     }
 

--- a/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
+++ b/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
@@ -150,7 +150,6 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
         onlyMessageProxy
         whenNotKilled(schainHash)
         checkReceiverChain(schainHash, sender)
-        returns (address)
     {
         Messages.TransferErc20Message memory message = Messages.decodeTransferErc20Message(data);
         require(message.token.isContract(), "Given address is not a contract");
@@ -160,7 +159,6 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
             ERC20Upgradeable(message.token).transfer(message.receiver, message.amount),
             "Transfer was failed"
         );
-        return message.receiver;
     }
 
     /**

--- a/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC721.sol
+++ b/proxy/contracts/mainnet/DepositBoxes/DepositBoxERC721.sol
@@ -140,14 +140,12 @@ contract DepositBoxERC721 is DepositBox, IDepositBoxERC721 {
         onlyMessageProxy
         whenNotKilled(schainHash)
         checkReceiverChain(schainHash, sender)
-        returns (address)
     {
         Messages.TransferErc721Message memory message = Messages.decodeTransferErc721Message(data);
         require(message.token.isContract(), "Given address is not a contract");
         require(IERC721Upgradeable(message.token).ownerOf(message.tokenId) == address(this), "Incorrect tokenId");
         _removeTransferredAmount(message.token, message.tokenId);
         IERC721Upgradeable(message.token).transferFrom(address(this), message.receiver, message.tokenId);
-        return message.receiver;
     }
 
     /**

--- a/proxy/contracts/mainnet/DepositBoxes/DepositBoxEth.sol
+++ b/proxy/contracts/mainnet/DepositBoxes/DepositBoxEth.sol
@@ -94,7 +94,6 @@ contract DepositBoxEth is DepositBox, IDepositBoxEth {
         onlyMessageProxy
         whenNotKilled(schainHash)
         checkReceiverChain(schainHash, sender)
-        returns (address)
     {
         Messages.TransferEthMessage memory message = Messages.decodeTransferEthMessage(data);
         require(
@@ -107,7 +106,6 @@ contract DepositBoxEth is DepositBox, IDepositBoxEth {
         } else {
             payable(message.receiver).sendValue(message.amount);
         }
-        return message.receiver;
     }
 
     /**

--- a/proxy/contracts/schain/CommunityLocker.sol
+++ b/proxy/contracts/schain/CommunityLocker.sol
@@ -137,7 +137,6 @@ contract CommunityLocker is ICommunityLocker, AccessControlEnumerableUpgradeable
     )
         external
         override
-        returns (address)
     {
         require(msg.sender == address(messageProxy), "Sender is not a message proxy");
         require(sender == communityPool, "Sender must be CommunityPool");
@@ -152,7 +151,6 @@ contract CommunityLocker is ICommunityLocker, AccessControlEnumerableUpgradeable
         } else {
             emit LockUser(schainHash, message.receiver);
         }
-        return message.receiver;
     }
 
     /**

--- a/proxy/contracts/schain/TokenManagers/TokenManagerERC1155.sol
+++ b/proxy/contracts/schain/TokenManagers/TokenManagerERC1155.sol
@@ -218,7 +218,6 @@ contract TokenManagerERC1155 is
         override
         onlyMessageProxy
         checkReceiverChain(fromChainHash, sender)
-        returns (address)
     {
         Messages.MessageType operation = Messages.getMessageType(data);
         address receiver = address(0);
@@ -235,7 +234,6 @@ contract TokenManagerERC1155 is
         } else {
             revert("MessageType is unknown");
         }
-        return receiver;
     }
 
     /**

--- a/proxy/contracts/schain/TokenManagers/TokenManagerERC20.sol
+++ b/proxy/contracts/schain/TokenManagers/TokenManagerERC20.sol
@@ -168,7 +168,6 @@ contract TokenManagerERC20 is TokenManager, ITokenManagerERC20InitializeFunction
         override
         onlyMessageProxy
         checkReceiverChain(fromChainHash, sender)
-        returns (address)
     {
         Messages.MessageType operation = Messages.getMessageType(data);
         address receiver = address(0);
@@ -181,7 +180,6 @@ contract TokenManagerERC20 is TokenManager, ITokenManagerERC20InitializeFunction
         } else {
             revert("MessageType is unknown");
         }
-        return receiver;
     }
 
     /**

--- a/proxy/contracts/schain/TokenManagers/TokenManagerERC721.sol
+++ b/proxy/contracts/schain/TokenManagers/TokenManagerERC721.sol
@@ -167,7 +167,6 @@ contract TokenManagerERC721 is TokenManager, ITokenManagerERC721InitializeFuncti
         override
         onlyMessageProxy
         checkReceiverChain(fromChainHash, sender)
-        returns (address)
     {
         Messages.MessageType operation = Messages.getMessageType(data);
         address receiver = address(0);
@@ -179,7 +178,6 @@ contract TokenManagerERC721 is TokenManager, ITokenManagerERC721InitializeFuncti
         } else {
             revert("MessageType is unknown");
         }
-        return receiver;
     }
 
     /**

--- a/proxy/contracts/schain/TokenManagers/TokenManagerEth.sol
+++ b/proxy/contracts/schain/TokenManagers/TokenManagerEth.sol
@@ -76,13 +76,11 @@ contract TokenManagerEth is TokenManager, ITokenManagerEth {
         override
         onlyMessageProxy
         checkReceiverChain(fromChainHash, sender)
-        returns (address)
     {
         Messages.TransferEthMessage memory decodedMessage = Messages.decodeTransferEthMessage(data);
         address receiver = decodedMessage.receiver;
         require(receiver != address(0), "Incorrect receiver");
         ethErc20.mint(receiver, decodedMessage.amount);
-        return receiver;
     }
 
     /**

--- a/proxy/contracts/test/ReceiverGasLimitMainnetMock.sol
+++ b/proxy/contracts/test/ReceiverGasLimitMainnetMock.sol
@@ -34,11 +34,9 @@ contract ReceiverGasLimitMainnetMock is IMessageReceiver {
     )
         external
         override
-        returns (address) 
     {
         while(true) {
             a++;
         }
-        return address(0);
     }
 }

--- a/proxy/contracts/test/ReceiverGasLimitSchainMock.sol
+++ b/proxy/contracts/test/ReceiverGasLimitSchainMock.sol
@@ -34,11 +34,9 @@ contract ReceiverGasLimitSchainMock is IMessageReceiver {
     )
         external
         override
-        returns (address) 
     {
         while(true) {
             a++;
         }
-        return address(0);
     }
 }

--- a/proxy/contracts/test/ReceiverMock.sol
+++ b/proxy/contracts/test/ReceiverMock.sol
@@ -34,8 +34,7 @@ contract ReceiverMock is IMessageReceiver {
         external
         pure
         override
-        returns (address) 
     {
-        return address(0);
+        return;
     }
 }

--- a/proxy/contracts/test/TestCallReceiverContract.sol
+++ b/proxy/contracts/test/TestCallReceiverContract.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ *   ReceiverMock.sol - SKALE Interchain Messaging Agent
+ *   Copyright (C) 2021-Present SKALE Labs
+ *   @author Dmytro Stebaiev
+ *
+ *   SKALE IMA is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published
+ *   by the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   SKALE IMA is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with SKALE IMA.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+pragma solidity 0.8.6;
+
+import "@skalenetwork/ima-interfaces/IMessageReceiver.sol";
+
+
+contract TestCallReceiverContract is IMessageReceiver {
+    event Error(uint error);
+
+    function postMessage(
+        bytes32,
+        address,
+        bytes calldata data
+    )
+        external
+        override
+    {
+        uint revertCode = abi.decode(data, (uint));
+        uint one = 1;
+        uint zero = 0;
+        if (revertCode == 1) {
+            revert("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        } else if (revertCode == 2) {
+            emit Error(one / zero);
+        }
+    }
+}

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -25,7 +25,7 @@
         "@openzeppelin/contracts-upgradeable": "^4.3.2",
         "@openzeppelin/hardhat-upgrades": "^1.9.0",
         "@skalenetwork/etherbase-interfaces": "^0.0.1-develop.20",
-        "@skalenetwork/ima-interfaces": "1.0.0-develop.14",
+        "@skalenetwork/ima-interfaces": "1.0.0-develop.15",
         "@skalenetwork/skale-manager-interfaces": "^0.1.2",
         "axios": "^0.21.4",
         "dotenv": "^10.0.0",

--- a/proxy/yarn.lock
+++ b/proxy/yarn.lock
@@ -757,10 +757,10 @@
   resolved "https://registry.yarnpkg.com/@skalenetwork/etherbase-interfaces/-/etherbase-interfaces-0.0.1-develop.20.tgz#33f61e18d695fd47063aa39dce4df335d26b9528"
   integrity sha512-j3xnuQtOtjvjAoUMJgSUFxRa9/Egkg1RyA8r6PjcEb33VksE4LWLBy0PNFUFehLZv48595JROTcViGeXXwg5HQ==
 
-"@skalenetwork/ima-interfaces@1.0.0-develop.14":
-  version "1.0.0-develop.14"
-  resolved "https://registry.yarnpkg.com/@skalenetwork/ima-interfaces/-/ima-interfaces-1.0.0-develop.14.tgz#51efd2fa0ed3bc12c2a9a0e3a97dfff8dd98a9c8"
-  integrity sha512-R3rJl1u5c9miAFbE07YjII9uRZNZAVT7BaeKgMer69plVRnIf3Sd9NLth8K/e9ATLIjb7V0tk7mz32E3ptF+Ow==
+"@skalenetwork/ima-interfaces@1.0.0-develop.15":
+  version "1.0.0-develop.15"
+  resolved "https://registry.yarnpkg.com/@skalenetwork/ima-interfaces/-/ima-interfaces-1.0.0-develop.15.tgz#111c6f58ceb43a728ed1fd9e1da7d16eb1a7b0c0"
+  integrity sha512-R8fDUjxuoXzq3h4jWEBJR63Y2icAK6U3x4o5jE1PoPcv19VoWN5iWgkh/1vge4W3zQ8jgvn4vB50gOvSEN02pA==
   dependencies:
     "@skalenetwork/skale-manager-interfaces" "^0.1.2"
 


### PR DESCRIPTION
1. Revert message was limited to 64 characters.
2. _callReceiverContract now handle Panic reverts
3. Removed all unused returns in postMessage