### PR TITLE
Removed response for get_last_transfer_errors

### DIFF
--- a/agent/main.js
+++ b/agent/main.js
@@ -2183,8 +2183,8 @@ if( imaState.nMonitoringPort > 0 ) {
                     } break;
                 case "get_last_transfer_errors":
                     // call:   { "id": 1, "method": "get_last_transfer_errors" }
-                    // answer: { "id": 1, "method": "get_last_transfer_errors", "error": null, "last_transfer_errors": [ { ts: ..., textLog: ... }, ... ] }
-                    joAnswer.last_transfer_errors = IMA.get_last_transfer_errors();
+                    // answer: { "id": 1, "method": "get_last_transfer_errors", "isIncludeTextLog": true, "error": null, "last_transfer_errors": [ { ts: ..., textLog: ... }, ... ] }
+                    joAnswer.last_transfer_errors = IMA.get_last_transfer_errors( ( ( "isIncludeTextLog" in joMessage ) && joMessage.isIncludeTextLog ) ? true : false );
                     joAnswer.last_error_categories = IMA.get_last_error_categories();
                     break;
                 default:

--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -605,7 +605,7 @@ function get_last_transfer_errors( isIncludeTextLog ) {
     const jarr = JSON.parse( JSON.stringify( g_arrLastTransferErrors ) );
     if( ! isIncludeTextLog ) {
         for( let i = 0; i < jarr.length; ++ i ) {
-            const jo = jarr[ i ];
+            const jo = jarr[i];
             if( "textLog" in jo )
                 delete jo.textLog;
         }

--- a/npms/skale-ima/index.js
+++ b/npms/skale-ima/index.js
@@ -599,8 +599,18 @@ function save_transfer_success_all() {
     g_mapTransferErrorCategories = { }; // clear all transfer error categories, out of time frame
 }
 
-function get_last_transfer_errors() {
-    return JSON.parse( JSON.stringify( g_arrLastTransferErrors ) );
+function get_last_transfer_errors( isIncludeTextLog ) {
+    if( typeof isIncludeTextLog == "undefined" )
+        isIncludeTextLog = true;
+    const jarr = JSON.parse( JSON.stringify( g_arrLastTransferErrors ) );
+    if( ! isIncludeTextLog ) {
+        for( let i = 0; i < jarr.length; ++ i ) {
+            const jo = jarr[ i ];
+            if( "textLog" in jo )
+                delete jo.textLog;
+        }
+    } // if( ! isIncludeTextLog )
+    return jarr;
 }
 
 function get_last_error_categories() {


### PR DESCRIPTION
Removed response for `get_last_transfer_errors`. Call examples:
`>>> wscat -c ws://127.0.0.1:29400 -x '{ "id": 1, "method": "get_last_transfer_errors" }' | jq`
`>>> wscat -c ws://127.0.0.1:29400 -x '{ "id": 1, "method": "get_last_transfer_errors", "isIncludeTextLog": false }' | jq`
`>>> wscat -c ws://127.0.0.1:29400 -x '{ "id": 1, "method": "get_last_transfer_errors", "isIncludeTextLog": true }' | jq`
Now long `textLog` values are not included into JSON answer until `"isIncludeTextLog": true` is specified in call.