### PR TITLE
Improved skale_imaVerifyAndSign JSON RPC call

### DIFF
--- a/agent/bls.js
+++ b/agent/bls.js
@@ -864,8 +864,15 @@ async function do_sign_messages_impl(
         //     }
         // }
         //
-        details.write( strLogPrefix + cc.debug( "Will sign " ) + cc.info( jarrMessages.length ) + cc.debug( " message(s)..." ) + "\n" );
-        log.write( strLogPrefix + cc.debug( "Will sign " ) + cc.j( jarrMessages ) + cc.debug( " message(s)..." ) + "\n" );
+        const sequence_id = owaspUtils.remove_starting_0x( get_w3().utils.soliditySha3( log.generate_timestamp_string( null, false ) ) );
+        details.write( strLogPrefix +
+            cc.debug( "Will sign " ) + cc.info( jarrMessages.length ) + cc.debug( " message(s)" ) +
+            cc.debug( ", " ) + cc.notice( "sequence ID" ) + cc.debug( " is " ) + cc.attention( sequence_id ) +
+            cc.debug( "..." ) + "\n" );
+        log.write( strLogPrefix +
+            cc.debug( "Will sign " ) + cc.j( jarrMessages ) + cc.debug( " message(s)" ) +
+            cc.debug( ", " ) + cc.notice( "sequence ID" ) + cc.debug( " is " ) + cc.attention( sequence_id ) +
+            cc.debug( "..." ) + "\n" );
         const jarrNodes = imaState.joSChainNetworkInfo.network;
         details.write( strLogPrefix + cc.debug( "Will query to sign " ) + cc.info( jarrNodes.length ) + cc.debug( " skaled node(s)..." ) + "\n" );
         const nThreshold = discover_bls_threshold( imaState.joSChainNetworkInfo );
@@ -884,13 +891,21 @@ async function do_sign_messages_impl(
         //     details.write( strLogPrefix + cc.warning( "Minimal BLS parts number for dicovery was increased." ) + "\n" );
         //     nCountOfBlsPartsToCollect = 2;
         // }
-        log.write( strLogPrefix + cc.debug( "Will collect " ) + cc.info( nCountOfBlsPartsToCollect ) + cc.debug( " signature(s)" ) + "\n" );
-        details.write( strLogPrefix + cc.debug( "Will collect " ) + cc.info( nCountOfBlsPartsToCollect ) + cc.debug( " from " ) + cc.info( jarrNodes.length ) + cc.debug( " nodes" ) + "\n" );
+        log.write( strLogPrefix +
+            cc.debug( "Will collect " ) + cc.info( nCountOfBlsPartsToCollect ) + cc.debug( " signature(s)" ) +
+            cc.debug( ", " ) + cc.notice( "sequence ID" ) + cc.debug( " is " ) + cc.attention( sequence_id ) +
+            "\n" );
+        details.write( strLogPrefix +
+            cc.debug( "Will collect " ) + cc.info( nCountOfBlsPartsToCollect ) + cc.debug( " from " ) +
+            cc.info( jarrNodes.length ) + cc.debug( " nodes" ) +
+            cc.debug( ", " ) + cc.notice( "sequence ID" ) + cc.debug( " is " ) + cc.attention( sequence_id ) +
+            "\n" );
         for( let i = 0; i < jarrNodes.length; ++i ) {
             const joNode = jarrNodes[i];
             const strNodeURL = imaUtils.compose_schain_node_url( joNode );
             const strNodeDescColorized = cc.u( strNodeURL ) + " " +
-                cc.normal( "(" ) + cc.bright( i ) + cc.normal( "/" ) + cc.bright( jarrNodes.length ) + cc.normal( ", ID " ) + cc.info( joNode.nodeID ) + cc.normal( ")" );
+                cc.normal( "(" ) + cc.bright( i ) + cc.normal( "/" ) + cc.bright( jarrNodes.length ) + cc.normal( ", ID " ) + cc.info( joNode.nodeID ) + cc.normal( ")" ) +
+                cc.normal( ", " ) + cc.notice( "sequence ID" ) + cc.normal( " is " ) + cc.attention( sequence_id );
             const rpcCallOpts = null;
             await rpcCall.create( strNodeURL, rpcCallOpts, async function( joCall, err ) {
                 if( err ) {
@@ -899,7 +914,9 @@ async function do_sign_messages_impl(
                     const strErrorMessage =
                         strLogPrefix + cc.fatal( "CRITICAL ERROR:" ) +
                         cc.error( " JSON RPC call to S-Chain node " ) + strNodeDescColorized +
-                        cc.error( " failed, RPC call was not created, error: " ) + cc.warning( err ) + "\n";
+                        cc.error( " failed, RPC call was not created, error: " ) + cc.warning( err ) +
+                        cc.error( ", " ) + cc.notice( "sequence ID" ) + cc.error( " is " ) + cc.attention( sequence_id ) +
+                        "\n";
                     log.write( strErrorMessage );
                     details.write( strErrorMessage );
                     return;
@@ -936,14 +953,21 @@ async function do_sign_messages_impl(
                     // targetChainURL: targetChainURL
                 };
                 details.write(
-                    strLogPrefix + cc.debug( "Will invoke " ) + cc.info( "skale_imaVerifyAndSign" ) +
+                    strLogPrefix + log.generate_timestamp_string( null, true ) + " " +
+                    cc.debug( "Will invoke " ) + cc.info( "skale_imaVerifyAndSign" ) +
                     cc.debug( " for transfer from chain " ) + cc.info( fromChainName ) +
                     cc.debug( " to chain " ) + cc.info( targetChainName ) +
                     cc.debug( " with params " ) + cc.j( joParams ) +
+                    cc.debug( ", " ) + cc.notice( "sequence ID" ) + cc.debug( " is " ) + cc.attention( sequence_id ) +
                     "\n" );
                 await joCall.call( {
                     method: "skale_imaVerifyAndSign",
-                    params: joParams
+                    params: joParams,
+                    qa: {
+                        skaled_no: 0 + i,
+                        sequence_id: "" + sequence_id,
+                        ts: "" + log.generate_timestamp_string( null, false )
+                    }
                 }, async function( joIn, joOut, err ) {
                     ++joGatheringTracker.nCountReceived; // including errors
                     if( err ) {
@@ -951,17 +975,21 @@ async function do_sign_messages_impl(
                         const strErrorMessage =
                             strLogPrefix + cc.fatal( "CRITICAL ERROR:" ) +
                             cc.error( " JSON RPC call to S-Chain node " ) + strNodeDescColorized +
-                            cc.error( " failed, RPC call reported error: " ) + cc.warning( err ) + "\n";
+                            cc.error( " failed, RPC call reported error: " ) + cc.warning( err ) +
+                            cc.error( ", " ) + cc.notice( "sequence ID" ) + cc.error( " is " ) + cc.attention( sequence_id ) +
+                            "\n";
                         log.write( strErrorMessage );
                         details.write( strErrorMessage );
                         return;
                     }
                     details.write(
-                        strLogPrefix + cc.debug( "Got answer from " ) + cc.info( "skale_imaVerifyAndSign" ) +
+                        strLogPrefix + log.generate_timestamp_string( null, true ) + " " +
+                        cc.debug( "Got answer from " ) + cc.info( "skale_imaVerifyAndSign" ) +
                         cc.debug( " for transfer from chain " ) + cc.info( fromChainName ) +
                         cc.debug( " to chain " ) + cc.info( targetChainName ) +
                         cc.debug( " with params " ) + cc.j( joParams ) +
                         cc.debug( ", answer is " ) + cc.j( joOut ) +
+                        cc.debug( ", " ) + cc.notice( "sequence ID" ) + cc.debug( " is " ) + cc.attention( sequence_id ) +
                         "\n" );
                     if( joOut.result == null || joOut.result == undefined || ( !typeof joOut.result == "object" ) ) {
                         ++joGatheringTracker.nCountErrors;
@@ -969,14 +997,18 @@ async function do_sign_messages_impl(
                             const strErrorMessage =
                                 strLogPrefix + cc.fatal( "Wallet CRITICAL ERROR:" ) + " " +
                                 cc.error( "S-Chain node " ) + strNodeDescColorized +
-                                cc.error( " reported wallet error: " ) + cc.warning( joOut.error.message ) + "\n";
+                                cc.error( " reported wallet error: " ) + cc.warning( joOut.error.message ) +
+                                cc.error( ", " ) + cc.notice( "sequence ID" ) + cc.error( " is " ) + cc.attention( sequence_id ) +
+                                "\n";
                             log.write( strErrorMessage );
                             details.write( strErrorMessage );
                         } else {
                             const strErrorMessage =
                                 strLogPrefix + cc.fatal( "Wallet CRITICAL ERROR:" ) + " " +
                                 cc.error( "JSON RPC call to S-Chain node " ) + strNodeDescColorized +
-                                cc.error( " failed with " ) + cc.warning( "unknown wallet error" ) + "\n";
+                                cc.error( " failed with " ) + cc.warning( "unknown wallet error" ) +
+                                cc.error( ", " ) + cc.notice( "sequence ID" ) + cc.error( " is " ) + cc.attention( sequence_id ) +
+                                "\n";
                             log.write( strErrorMessage );
                             details.write( strErrorMessage );
                         }
@@ -1030,7 +1062,9 @@ async function do_sign_messages_impl(
                                 const strErrorMessage =
                                     strLogPrefixA + cc.error( "S-Chain node " ) + strNodeDescColorized + cc.error( " sign " ) +
                                     cc.error( " CRITICAL ERROR:" ) + cc.error( " partial signature fail from with index " ) + cc.info( nZeroBasedNodeIndex ) +
-                                    cc.error( ", error is " ) + cc.warning( err.toString() ) + "\n";
+                                    cc.error( ", error is " ) + cc.warning( err.toString() ) +
+                                    cc.error( ", " ) + cc.notice( "sequence ID" ) + cc.error( " is " ) + cc.attention( sequence_id ) +
+                                    "\n";
                                 log.write( strErrorMessage );
                                 details.write( strErrorMessage );
                             }
@@ -1059,7 +1093,9 @@ async function do_sign_messages_impl(
                         const strErrorMessage =
                             strLogPrefix + cc.error( "S-Chain node " ) + strNodeDescColorized + " " + cc.fatal( "CRITICAL ERROR:" ) +
                             cc.error( " signature fail from node " ) + cc.info( joNode.nodeID ) +
-                            cc.error( ", error is " ) + cc.warning( err.toString() ) + "\n";
+                            cc.error( ", error is " ) + cc.warning( err.toString() ) +
+                            cc.error( ", " ) + cc.notice( "sequence ID" ) + cc.error( " is " ) + cc.attention( sequence_id ) +
+                            "\n";
                         log.write( strErrorMessage );
                         details.write( strErrorMessage );
                     }

--- a/npms/skale-log/log.js
+++ b/npms/skale-log/log.js
@@ -37,22 +37,27 @@ function n2s( n, sz ) {
     return s;
 }
 
-function generateTimestamp() {
-    const ts = new Date();
+function generate_timestamp_string( ts, isColorized ) {
+    isColorized = ( typeof isColorized == "undefined" ) ? true : ( isColorized ? true : false );
+    ts = ( ts instanceof Date ) ? ts : new Date();
+    const cc_date = function( x ) { return isColorized ? cc.date( x ) : x; };
+    const cc_time = function( x ) { return isColorized ? cc.time( x ) : x; };
+    const cc_frac_time = function( x ) { return isColorized ? cc.frac_time( x ) : x; };
+    const cc_bright = function( x ) { return isColorized ? cc.bright( x ) : x; };
     const s =
-	"" + cc.date( n2s( ts.getUTCFullYear(), 4 ) ) +
-	cc.bright( "-" ) + cc.date( n2s( ts.getUTCMonth() + 1, 2 ) ) +
-	cc.bright( "-" ) + cc.date( n2s( ts.getUTCDate(), 2 ) ) +
-	" " + cc.time( n2s( ts.getUTCHours(), 2 ) ) +
-	cc.bright( ":" ) + cc.time( n2s( ts.getUTCMinutes(), 2 ) ) +
-	cc.bright( ":" ) + cc.time( n2s( ts.getUTCSeconds(), 2 ) ) +
-	cc.bright( "." ) + cc.frac_time( n2s( ts.getUTCMilliseconds(), 3 ) )
-	;
+        "" + cc_date( n2s( ts.getUTCFullYear(), 4 ) ) +
+        cc_bright( "-" ) + cc_date( n2s( ts.getUTCMonth() + 1, 2 ) ) +
+        cc_bright( "-" ) + cc_date( n2s( ts.getUTCDate(), 2 ) ) +
+        " " + cc_time( n2s( ts.getUTCHours(), 2 ) ) +
+        cc_bright( ":" ) + cc_time( n2s( ts.getUTCMinutes(), 2 ) ) +
+        cc_bright( ":" ) + cc_time( n2s( ts.getUTCSeconds(), 2 ) ) +
+        cc_bright( "." ) + cc_frac_time( n2s( ts.getUTCMilliseconds(), 3 ) )
+        ;
     return s;
 }
 
-function generateTimestampPrefix() {
-    return generateTimestamp() + cc.bright( ":" ) + " ";
+function generate_timestamp_prefix( ts, isColorized ) {
+    return generate_timestamp_string( ts, isColorized ) + cc.bright( ":" ) + " ";
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -251,9 +256,11 @@ function insertFileOutput( strFilePath, nMaxSizeBeforeRotation, nMaxFilesCount )
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 module.exports = {
+    generate_timestamp_string: generate_timestamp_string,
+    generate_timestamp_prefix: generate_timestamp_prefix,
     cc: cc,
-	  write: function() {
-        let s = generateTimestampPrefix(); let i = 0; let cnt = 0;
+    write: function() {
+        let s = generate_timestamp_prefix( null, true ); let i = 0; let cnt = 0;
         try {
             for( i = 0; i < arguments.length; ++i ) {
                 try {


### PR DESCRIPTION
- `skale_imaVerifyAndSign` call is logged with timestamps in **IMA agent**
- call JSON of skale_imaVerifyAndSign now contains new sub part `"qa":{"sequence_id":"3c2e3a476ee7711c7c58fb21e4d39689ac72546ae910df36e699cfa75adc93ce","skaled_no":0,"ts":"2022-05-13 20:06:51.546"}` where `sequence_id` is something unique you can search in logs of all `16` skaleds, `skaled_no` is `0..15`, `ts` is UTC time when call was sent on **IMA agent** side