### PR TITLE
ticket-1554 Event log search filters are using BN numbers for IMA message numbers

### DIFF
--- a/npms/skale-ima/imaEventLogScan.mjs
+++ b/npms/skale-ima/imaEventLogScan.mjs
@@ -396,12 +396,12 @@ export async function safeGetPastEvents(
     if( retValOnFail == null || retValOnFail == undefined )
         retValOnFail = "";
     let ret = retValOnFail;
+    const nLatestBlockNumber = owaspUtils.toBN(
+        await imaHelperAPIs.safeGetBlockNumber( details, 10, ethersProvider ) );
     let idxAttempt = 1;
     const strErrorTextAboutNotExistingEvent =
         "Event \"" + strEventName + "\" doesn't exist in this contract";
     if( nBlockTo == "latest" ) {
-        const nLatestBlockNumber = owaspUtils.toBN(
-            await imaHelperAPIs.safeGetBlockNumber( details, 10, ethersProvider ) );
         const nLatestBlockNumberPlus1 = nLatestBlockNumber.add( owaspUtils.toBN( 1 ) );
         nBlockTo = nLatestBlockNumberPlus1;
     } else
@@ -412,7 +412,9 @@ export async function safeGetPastEvents(
             details.write( strLogPrefix + cc.debug( "First time, will query filter " ) +
                 cc.j( joFilter ) + cc.debug( " on contract " ) + cc.info( joContract.address ) +
                 cc.debug( " from block " ) + cc.info( nBlockFrom.toHexString() ) +
-                cc.debug( " to block " ) + cc.info( nBlockTo.toHexString() ) + "\n" );
+                cc.debug( " to block " ) + cc.info( nBlockTo.toHexString() ) +
+                cc.debug( " while current latest block number on chain is " ) +
+                cc.info( nLatestBlockNumber.toHexString() ) + "\n" );
         }
         ret =
             await joContract.queryFilter(

--- a/npms/skale-ima/index.mjs
+++ b/npms/skale-ima/index.mjs
@@ -327,7 +327,7 @@ async function doQueryOutgoingMessageCounter( optsTransfer ) {
     ) {
         const joFilter = optsTransfer.joMessageProxySrc.filters[strEventName](
             owaspUtils.ethersMod.ethers.utils.id( optsTransfer.chainIdDst ), // dstChainHash
-            nWalkMsgNumber
+            owaspUtils.toBN( nWalkMsgNumber )
         );
         const arrLogRecordReferencesWalk = await imaEventLogScan.safeGetPastEventsProgressive(
             optsTransfer.details, optsTransfer.strLogPrefixShort,
@@ -437,7 +437,7 @@ async function gatherMessages( optsTransfer ) {
             10, optsTransfer.joMessageProxySrc, strEventName, nBlockFrom, nBlockTo,
             optsTransfer.joMessageProxySrc.filters[strEventName](
                 owaspUtils.ethersMod.ethers.utils.id( optsTransfer.chainNameDst ), // dstChainHash
-                optsTransfer.nIdxCurrentMsg // msgCounter
+                owaspUtils.toBN( optsTransfer.nIdxCurrentMsg )
             ) );
         const joValues = await analyzeGatheredRecords( optsTransfer, r );
         if( joValues == null )
@@ -923,7 +923,7 @@ async function checkOutgoingMessageEvent( optsTransfer, joSChain ) {
                         joMessage.savedBlockNumberForOptimizations,
                         joMessageProxyNode.filters[strEventName](
                             owaspUtils.ethersMod.ethers.utils.id( optsTransfer.chainNameDst ),
-                            idxImaMessage // msgCounter
+                            owaspUtils.toBN( idxImaMessage )
                         )
                     );
                     const cntEvents = node_r.length;


### PR DESCRIPTION
Event log search filters are using BN numbers for IMA message numbers
Added text logs displaying matches of upper block number in event log search range and current block number