### PR TITLE
ticket-1621 fixed IMA Agent crash during BLS verification writes error message to log output

### DIFF
--- a/agent/bls.mjs
+++ b/agent/bls.mjs
@@ -1271,7 +1271,7 @@ async function gatherSigningStartImpl( optsSignOperation ) {
                         "\n";
                     if( log.verboseGet() >= log.verboseReversed().error ) {
                         optsSignOperation.details.write( strErrorMessage );
-                        if( log.id != details.id )
+                        if( log.id != optsSignOperation.details.id )
                             log.write( strErrorMessage );
                     }
                 }


### PR DESCRIPTION
Fixed IMA Agent crash during BLS verification writes error message to log output.
Crash was caused by misprint in code.
Only existing QA tests are needed to verify fix.