### PR TITLE
Update gas price calculation in CommunityPool contract

### DIFF
--- a/proxy/contracts/mainnet/CommunityPool.sol
+++ b/proxy/contracts/mainnet/CommunityPool.sol
@@ -262,6 +262,7 @@ contract CommunityPool is Twin, ICommunityPool {
         override
         returns (uint256)
     {
+        require(tx.gasprice != 0, "Gas price is zero");
         uint256 currentValue = _multiplyOnAdaptedBaseFee(minTransactionGas);
         if (currentValue  <= _userWallets[receiver][schainHash]) {
             return 0;
@@ -273,10 +274,10 @@ contract CommunityPool is Twin, ICommunityPool {
      * @dev Checks whether user wallet was recharged for sufficient amount.
      */
     function _balanceIsSufficient(bytes32 schainHash, address receiver, uint256 delta) private view returns (bool) {
-        return delta + _userWallets[receiver][schainHash] >= minTransactionGas * tx.gasprice;
+        return delta + _userWallets[receiver][schainHash] >= minTransactionGas * block.basefee;
     }
 
     function _multiplyOnAdaptedBaseFee(uint256 value) private view returns (uint256) {
-        return value * block.basefee * multiplierNumerator / multiplierDivider;
+        return value * tx.gasprice * multiplierNumerator / multiplierDivider;
     }
 }


### PR DESCRIPTION
During a recent investigation, it was found that block.basefee in the call returns 0, so it was decided to return tx.gasprice back and set it ourselves during the call to getRecommendedRechargeAmount. Also, in the _balanceIsSufficient method, tx.gasprice was replaced with block.basefee, which avoids manipulation of the gasprice during the call to rechargeUserWallet.