### PR TITLE
Refactor upgrade scripts to remove ABI update logic and adjust enviro…

### DIFF
--- a/migrations/upgradeMainnet.ts
+++ b/migrations/upgradeMainnet.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
 import { ethers } from "hardhat";
-import { promises as fs } from 'fs';
 import { Transaction } from "ethers";
-import { getAbi, getVersion, Submitter, Upgrader } from "@skalenetwork/upgrade-tools";
+import { Submitter, Upgrader } from "@skalenetwork/upgrade-tools";
 import { skaleContracts, Instance } from "@skalenetwork/skale-contracts-ethers-v6";
 import { MessageProxyForMainnet } from "../typechain";
-import { contracts, getContractKeyInAbiFile } from "./deployMainnet";
+import { contracts } from "./deployMainnet";
 
 
 async function getImaMainnetInstance() {
@@ -63,24 +62,6 @@ class ImaMainnetUpgrader extends Upgrader {
     // initialize = async () => { };
 }
 
-async function updateAbi() {
-    if (!process.env.ABI) {
-        console.log(chalk.red("Set path to file with ABI and addresses to ABI environment variables"));
-        process.exit(1);
-    }
-    const network = await ethers.provider.getNetwork();
-    const version = await getVersion();
-    const abiFilename = process.env.ABI;
-    const abi = JSON.parse(await fs.readFile(abiFilename, "utf-8"));
-    for (const contract of contracts) {
-        const contractInterface = (await ethers.getContractFactory(contract)).interface;
-        abi[getContractKeyInAbiFile(contract) + "_abi"] = getAbi(contractInterface);
-    }
-    const newAbiFilename = `data/mainnet-ima-${version}-${network.name}.json`;
-    await fs.writeFile(newAbiFilename, JSON.stringify(abi, null, 4));
-    console.log(chalk.green(`ABI updated and saved to ${newAbiFilename}`));
-}
-
 async function main() {
     let contractNamesToUpgrade: string[] = [];
     if (process.env.UPGRADE_ALL) {
@@ -92,7 +73,6 @@ async function main() {
         contractNamesToUpgrade
     );
     await upgrader.upgrade();
-    await updateAbi();
 }
 
 if (require.main === module) {

--- a/migrations/upgradeSchain.ts
+++ b/migrations/upgradeSchain.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { ethers } from "hardhat";
 import { promises as fs } from "fs";
 import { Transaction } from "ethers";
-import { getAbi, getVersion, Submitter, Upgrader } from "@skalenetwork/upgrade-tools";
+import { Submitter, Upgrader } from "@skalenetwork/upgrade-tools";
 import { skaleContracts, Instance } from "@skalenetwork/skale-contracts-ethers-v6";
 import { contracts, getContractKeyInAbiFile } from "./deploySchain";
 import { manifestSetup } from "./generateManifest";
@@ -20,11 +20,11 @@ async function getImaSchainInstance() {
     const project = network.getProject("schain-ima");
     const contractAddresses: ContractAddressMap = {};
     if (process.env.TEST_UPGRADE) {
-        if (!process.env.ABI) {
+        if (!process.env.TEST_ABI) {
             console.log(chalk.red("Set path to file with ABI and addresses to ABI environment variables"));
             process.exit(1);
         }
-        const abi = JSON.parse(await fs.readFile(process.env.ABI, "utf-8"));
+        const abi = JSON.parse(await fs.readFile(process.env.TEST_ABI, "utf-8"));
         for (const contract of contracts) {
             contractAddresses[contract] = abi[getContractKeyInAbiFile(contract) + "_address"];
         }
@@ -84,23 +84,6 @@ class ImaSchainUpgrader extends Upgrader {
     }
 }
 
-async function updateAbi(contracts: string[]) {
-    if (!process.env.ABI) {
-        console.log(chalk.red("Set path to file with ABI and addresses to ABI environment variables"));
-        process.exit(1);
-    }
-    const network = await ethers.provider.getNetwork();
-    const version = await getVersion();
-    const abiFilename = process.env.ABI;
-    const abi = JSON.parse(await fs.readFile(abiFilename, "utf-8"));
-    for (const contract of contracts) {
-        const contractInterface = (await ethers.getContractFactory(contract)).interface;
-        abi[getContractKeyInAbiFile(contract) + "_abi"] = getAbi(contractInterface);
-    }
-    const newAbiFilename = `data/schain-ima-${version}-${network.name}.json`;
-    await fs.writeFile(newAbiFilename, JSON.stringify(abi, null, 4));
-    console.log(chalk.green(`ABI updated and saved to ${newAbiFilename}`));
-}
 
 async function main() {
     const pathToManifest: string = process.env.MANIFEST || "";
@@ -116,7 +99,6 @@ async function main() {
         contractNamesToUpgrade
     );
     await upgrader.upgrade();
-    updateAbi(contracts);
 }
 
 if (require.main === module) {

--- a/scripts/test_upgrade.sh
+++ b/scripts/test_upgrade.sh
@@ -81,7 +81,7 @@ echo "$VERSION"
 
 MESSAGE_PROXY_FOR_SCHAIN=$(cat data/$ABI_FILENAME_SCHAIN | jq -r .message_proxy_chain_address)
 
-ABI="data/$ABI_FILENAME_SCHAIN" \
+TEST_ABI="data/$ABI_FILENAME_SCHAIN" \
 MANIFEST="data/ima-schain-$DEPLOYED_VERSION-manifest.json" \
 CHAIN_NAME_SCHAIN="Test" \
 UPGRADE_ALL="true" \


### PR DESCRIPTION
This pull request includes changes to the `migrations` and `scripts` directories to streamline the upgrade process by removing redundant ABI update functions and modifying environment variable usage.

### Removal of redundant ABI update functions:

* [`migrations/upgradeMainnet.ts`](diffhunk://#diff-006d14ad8a34aaba1d8c50196ca5f332952af2031b921e34ba3be2880f7f19bfL66-L83): Removed the `updateAbi` function and its invocation in the `main` function. [[1]](diffhunk://#diff-006d14ad8a34aaba1d8c50196ca5f332952af2031b921e34ba3be2880f7f19bfL66-L83) [[2]](diffhunk://#diff-006d14ad8a34aaba1d8c50196ca5f332952af2031b921e34ba3be2880f7f19bfL95)
* [`migrations/upgradeSchain.ts`](diffhunk://#diff-9fcad1b19669249e171049198f9742b3ecbe6762df5fd5fa4839c41c57c36fc5L87-L103): Removed the `updateAbi` function and its invocation in the `main` function. [[1]](diffhunk://#diff-9fcad1b19669249e171049198f9742b3ecbe6762df5fd5fa4839c41c57c36fc5L87-L103) [[2]](diffhunk://#diff-9fcad1b19669249e171049198f9742b3ecbe6762df5fd5fa4839c41c57c36fc5L119)

### Environment variable updates:

* [`migrations/upgradeMainnet.ts`](diffhunk://#diff-006d14ad8a34aaba1d8c50196ca5f332952af2031b921e34ba3be2880f7f19bfL3-R7): Removed unused imports and updated the ABI environment variable usage.
* [`migrations/upgradeSchain.ts`](diffhunk://#diff-9fcad1b19669249e171049198f9742b3ecbe6762df5fd5fa4839c41c57c36fc5L5-R5): Changed the environment variable from `ABI` to `TEST_ABI` for test upgrades. [[1]](diffhunk://#diff-9fcad1b19669249e171049198f9742b3ecbe6762df5fd5fa4839c41c57c36fc5L5-R5) [[2]](diffhunk://#diff-9fcad1b19669249e171049198f9742b3ecbe6762df5fd5fa4839c41c57c36fc5L23-R27)
* [`scripts/test_upgrade.sh`](diffhunk://#diff-a415bac0473af6be0bd066cca64c434e68c2028a18ad6022dc70d5b51de19d89L84-R84): Updated the environment variable from `ABI` to `TEST_ABI`.