### PR TITLE
Reorder arguments in CommunityPool initialization

### DIFF
--- a/migrations/deployMainnet.ts
+++ b/migrations/deployMainnet.ts
@@ -188,8 +188,8 @@ async function deployCommunityPool(
         "CommunityPool",
         [
             await contractManager.getAddress(),
-            await messageProxyForMainnet.getAddress(),
-            await linker.getAddress()
+            await linker.getAddress(),
+            await messageProxyForMainnet.getAddress()
         ],
         'initialize(address,address,address)'
     ) as unknown as CommunityPool;


### PR DESCRIPTION
Fixes bug in deployment script, order of params wasn't correct in deployCommunityPool.
Closes #1758 