### PR TITLE
fix reentrancy warning in depositBoxERC20

### DIFF
--- a/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
+++ b/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
@@ -121,6 +121,11 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
     event TransferSkipped(uint256 id);
 
     /**
+     * @dev Emitted when token transfer is not reverted
+     */
+    event TransferSucceeded(uint256 id);
+
+    /**
      * @dev Emitted when big transfer threshold is changed
      */
     event BigTransferThresholdIsChanged(
@@ -726,9 +731,9 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
     {
         for (uint256 i = 0; i < countToTransfer; ++i){
             DelayedTransfer memory transfer = transfers[i];
-            try this.doTransfer(transfer.token, transfer.receiver, transfer.amount)
-                // solhint-disable-next-line no-empty-blocks
-                {}
+            try this.doTransfer(transfer.token, transfer.receiver, transfer.amount) {
+                emit TransferSucceeded(transfersIds[i]);
+            }
             catch {
                 emit TransferSkipped(transfersIds[i]);
             }

--- a/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
+++ b/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
@@ -606,18 +606,14 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
             delayedTransfersByReceiver[receiver].length(),
             _QUEUE_PROCESSING_LIMIT
         );
-
         uint256 currentIndex = 0;
         bool retrieved = false;
-
         uint256 countToTransfer = 0;
         DelayedTransfer[] memory transfers = new DelayedTransfer[](transfersAmount);
         uint256[] memory transfersIds = new uint256[](transfersAmount);
         for (uint256 i = 0; i < transfersAmount; ++i) {
-            uint256 transferId = uint256(delayedTransfersByReceiver[receiver].at(currentIndex));
+            uint256 transferId = uint256(delayedTransfersByReceiver[receiver].at(currentIndex++));
             DelayedTransfer memory transfer = delayedTransfers[transferId];
-            ++currentIndex;
-
             if (transfer.status != DelayedTransferStatus.COMPLETED) {
                 if (block.timestamp < transfer.untilTimestamp) {
                     // disable detector until slither fixes false positive
@@ -625,12 +621,8 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
                     // slither-disable-next-line incorrect-equality
                     if (transfer.status == DelayedTransferStatus.DELAYED) {
                         break;
-                    } else {
-                        // status is ARBITRAGE
-                        continue;
-                    }
-                } else {
-                    // it's time to unlock
+                    } // else status is ARBITRAGE -> continue
+                } else { // it's time to unlock
                     if (currentIndex == 1) {
                         --currentIndex;
                         _removeOldestDelayedTransfer(receiver);
@@ -642,8 +634,7 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
                     transfersIds[countToTransfer] = transferId;
                     ++countToTransfer;
                 }
-            } else {
-                // status is COMPLETED
+            } else { // status is COMPLETED
                 if (currentIndex == 1) {
                     --currentIndex;
                     retrieved = true;
@@ -652,17 +643,7 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
             }
         }
         require(retrieved, "There are no transfers available for retrieving");
-
-        for (uint256 i = 0; i < countToTransfer; ++i){
-            uint256 transferId = transfersIds[i];
-            DelayedTransfer memory transfer = transfers[i];
-            try this.doTransfer(transfer.token, transfer.receiver, transfer.amount)
-                // solhint-disable-next-line no-empty-blocks
-                {}
-            catch {
-                emit TransferSkipped(transferId);
-            }
-        }
+        _doNTransfers(transfers, transfersIds, countToTransfer);
     }
 
     /**
@@ -733,6 +714,26 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
 
     // private
 
+    /**
+     * @dev Tries to do N amount of ERC20 transfers
+     */
+    function _doNTransfers(
+        DelayedTransfer[] memory transfers,
+        uint256[] memory transfersIds,
+        uint256 countToTransfer
+    )
+        private
+    {
+        for (uint256 i = 0; i < countToTransfer; ++i){
+            DelayedTransfer memory transfer = transfers[i];
+            try this.doTransfer(transfer.token, transfer.receiver, transfer.amount)
+                // solhint-disable-next-line no-empty-blocks
+                {}
+            catch {
+                emit TransferSkipped(transfersIds[i]);
+            }
+        }
+    }
     /**
      * @dev Saves amount of tokens that was transferred to schain.
      */

--- a/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
+++ b/contracts/mainnet/DepositBoxes/DepositBoxERC20.sol
@@ -598,11 +598,6 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
         return _delayConfig[schainHash].arbitrageDuration;
     }
 
-    // TODO:
-    // Known issue to fix in further releases.
-    // https://github.com/skalenetwork/IMA/issues/1717
-    // slither-disable-start reentrancy-no-eth
-
     /**
      * @dev Retrieve tokens that were unlocked after delay for specified receiver
      */
@@ -614,6 +609,10 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
 
         uint256 currentIndex = 0;
         bool retrieved = false;
+
+        uint256 countToTransfer = 0;
+        DelayedTransfer[] memory transfers = new DelayedTransfer[](transfersAmount);
+        uint256[] memory transfersIds = new uint256[](transfersAmount);
         for (uint256 i = 0; i < transfersAmount; ++i) {
             uint256 transferId = uint256(delayedTransfersByReceiver[receiver].at(currentIndex));
             DelayedTransfer memory transfer = delayedTransfers[transferId];
@@ -639,13 +638,9 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
                         delayedTransfers[transferId].status = DelayedTransferStatus.COMPLETED;
                     }
                     retrieved = true;
-                    try
-                        this.doTransfer(transfer.token, transfer.receiver, transfer.amount)
-                    // solhint-disable-next-line no-empty-blocks
-                    {}
-                    catch {
-                        emit TransferSkipped(transferId);
-                    }
+                    transfers[countToTransfer] = transfer;
+                    transfersIds[countToTransfer] = transferId;
+                    ++countToTransfer;
                 }
             } else {
                 // status is COMPLETED
@@ -657,8 +652,18 @@ contract DepositBoxERC20 is DepositBox, IDepositBoxERC20 {
             }
         }
         require(retrieved, "There are no transfers available for retrieving");
+
+        for (uint256 i = 0; i < countToTransfer; ++i){
+            uint256 transferId = transfersIds[i];
+            DelayedTransfer memory transfer = transfers[i];
+            try this.doTransfer(transfer.token, transfer.receiver, transfer.amount)
+                // solhint-disable-next-line no-empty-blocks
+                {}
+            catch {
+                emit TransferSkipped(transferId);
+            }
+        }
     }
-    // slither-disable-end reentrancy-no-eth
 
     /**
      * @dev Creates a new DepositBoxERC20 contract.

--- a/predeployed/setup.cfg
+++ b/predeployed/setup.cfg
@@ -19,6 +19,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =
+    web3>=6.0.0,<=7.10.0
     predeployed-generator >= 1.2.0
 
 [options.packages.find]

--- a/predeployed/test/requirements.txt
+++ b/predeployed/test/requirements.txt
@@ -1,2 +1,3 @@
+web3>=6.0.0,<=7.10.0 #failing with 7.12+ TODO: investigate
 predeployed-generator>=1.2.0
 setuptools


### PR DESCRIPTION
Fixes reentrancy warnings by changing order of execution. 
Fixes #1717 

Detected some issues with predeployed tests for web3>=7.11.0 . Limiting the version here for now.