### PR TITLE
Fix origin schain check in DepositBoxERC721

### DIFF
--- a/contracts/mainnet/DepositBoxes/DepositBoxERC721.sol
+++ b/contracts/mainnet/DepositBoxes/DepositBoxERC721.sol
@@ -103,7 +103,7 @@ contract DepositBoxERC721 is DepositBox, IDepositBoxERC721 {
     {
         Messages.TransferErc721Message memory message = Messages.decodeTransferErc721Message(data);
         require(message.token.isContract(), "Given address is not a contract");
-        require(IERC721Upgradeable(message.token).ownerOf(message.tokenId) == address(this), "Incorrect tokenId");
+        require(transferredAmount[message.token][message.tokenId] == schainHash, "Incorrect tokenId");
         _removeTransferredAmount(message.token, message.tokenId);
         IERC721Upgradeable(message.token).transferFrom(address(this), message.receiver, message.tokenId);
     }

--- a/contracts/mainnet/DepositBoxes/DepositBoxERC721WithMetadata.sol
+++ b/contracts/mainnet/DepositBoxes/DepositBoxERC721WithMetadata.sol
@@ -59,7 +59,10 @@ contract DepositBoxERC721WithMetadata is DepositBoxERC721 {
         Messages.TransferErc721MessageWithMetadata memory message =
             Messages.decodeTransferErc721MessageWithMetadata(data);
         require(message.erc721message.token.isContract(), "Given address is not a contract");
-        require(transferredAmount[message.erc721message.token][message.erc721message.tokenId] == schainHash, "Incorrect tokenId");
+        require(
+            transferredAmount[message.erc721message.token][message.erc721message.tokenId] == schainHash,
+            "Incorrect tokenId"
+        );
         _removeTransferredAmount(message.erc721message.token, message.erc721message.tokenId);
         IERC721Upgradeable(message.erc721message.token).transferFrom(
             address(this),

--- a/contracts/mainnet/DepositBoxes/DepositBoxERC721WithMetadata.sol
+++ b/contracts/mainnet/DepositBoxes/DepositBoxERC721WithMetadata.sol
@@ -59,10 +59,7 @@ contract DepositBoxERC721WithMetadata is DepositBoxERC721 {
         Messages.TransferErc721MessageWithMetadata memory message =
             Messages.decodeTransferErc721MessageWithMetadata(data);
         require(message.erc721message.token.isContract(), "Given address is not a contract");
-        require(
-            IERC721Upgradeable(message.erc721message.token).ownerOf(message.erc721message.tokenId) == address(this),
-            "Incorrect tokenId"
-        );
+        require(transferredAmount[message.erc721message.token][message.erc721message.tokenId] == schainHash, "Incorrect tokenId");
         _removeTransferredAmount(message.erc721message.token, message.erc721message.tokenId);
         IERC721Upgradeable(message.erc721message.token).transferFrom(
             address(this),

--- a/test/DepositBoxERC721.ts
+++ b/test/DepositBoxERC721.ts
@@ -323,7 +323,8 @@ describe("DepositBoxERC721", () => {
             };
 
             await erc721.connect(deployer).mint(deployer.address, tokenId);
-            await erc721.connect(deployer).transferFrom(deployer.address, depositBoxERC721, tokenId);
+            await erc721.connect(deployer).approve(depositBoxERC721, tokenId);
+            await depositBoxERC721.connect(deployer).depositERC721(schainName, erc721, tokenId);
 
             const balanceBefore = await getBalance(deployer.address);
             await messageProxy.connect(nodeAddress).postIncomingMessages(schainName, 0, [message], sign);
@@ -372,6 +373,47 @@ describe("DepositBoxERC721", () => {
             await expect(tx)
                 .to.emit(messageProxy, "PostMessageError")
                 .withArgs(0n, ethers.toUtf8Bytes("Incorrect tokenId"));
+        });
+
+        it("should reject ERC721 exit from a schain that did not receive the deposited NFT", async () => {
+            const tokenId = 10;
+            const attackerSchainName = "AttackerSchain";
+            const attacker = user2.address;
+            const senderFromAttackerSchain = deployer.address;
+
+            const message = {
+                data: await messages.encodeTransferErc721Message(erc721, attacker, tokenId),
+                destinationContract: depositBoxERC721,
+                sender: senderFromAttackerSchain
+            };
+
+            await initializeSchain(contractManager, attackerSchainName, user.address, 2, 1);
+            await addNodesToSchain(contractManager, attackerSchainName, [0]);
+            await rechargeSchainWallet(contractManager, attackerSchainName, user2.address, weiAmount);
+            await setCommonPublicKey(contractManager, attackerSchainName);
+            await linker
+                .connect(deployer)
+                .connectSchain(attackerSchainName, [deployer.address, deployer.address, deployer.address]);
+            await messageProxy.registerExtraContract(attackerSchainName, communityPool);
+            await communityPool
+                .connect(user)
+                .rechargeUserWallet(attackerSchainName, attacker, { value: weiAmount });
+
+            await erc721.mint(deployer.address, tokenId);
+            await erc721.approve(depositBoxERC721, tokenId);
+            await depositBoxERC721.depositERC721(schainName, erc721, tokenId);
+
+            const tx = await messageProxy.connect(nodeAddress).postIncomingMessages(
+                attackerSchainName,
+                0,
+                [message],
+                sign
+            );
+
+            await expect(tx)
+                .to.emit(messageProxy, "PostMessageError")
+                .withArgs(0n, ethers.toUtf8Bytes("Incorrect tokenId"));
+            expect(await erc721.ownerOf(tokenId)).to.equal(depositBoxERC721);
         });
 
         it("should transfer ERC721 token", async () => {

--- a/test/DepositBoxERC721WithMetadata.ts
+++ b/test/DepositBoxERC721WithMetadata.ts
@@ -329,7 +329,8 @@ describe("DepositBoxERC721WithMetadata", () => {
 
             await erc721.connect(deployer).mint(deployer.address, tokenId);
             await erc721.connect(deployer).setTokenURI(tokenId, tokenURI);
-            await erc721.connect(deployer).transferFrom(deployer.address, depositBoxERC721WithMetadata, tokenId);
+            await erc721.connect(deployer).approve(depositBoxERC721WithMetadata, tokenId);
+            await depositBoxERC721WithMetadata.connect(deployer).depositERC721(schainName, erc721, tokenId);
 
             const balanceBefore = await getBalance(deployer.address);
             await messageProxy.connect(nodeAddress).postIncomingMessages(schainName, 0, [message], sign);


### PR DESCRIPTION
Fixes #1805 
- Add test to assert failing/dangerous case
- Fix tests that just deposited the token directly without using the right function. Transfers should follow the call using `deposit` function.
- remove irrelevant ownership check.