### PR TITLE
Replace removed pkg_resources API

### DIFF
--- a/predeployed/src/ima_predeployed/contracts/message_proxy_for_schain.py
+++ b/predeployed/src/ima_predeployed/contracts/message_proxy_for_schain.py
@@ -1,4 +1,5 @@
 from os.path import join, dirname
+from importlib.metadata import version
 from typing import Dict
 
 from predeployed_generator.openzeppelin.access_control_enumerable_generator import (
@@ -10,7 +11,6 @@ from ..addresses import COMMUNITY_LOCKER_ADDRESS, KEY_STORAGE_ADDRESS, TOKEN_MAN
     TOKEN_MANAGER_ERC20_ADDRESS, TOKEN_MANAGER_ERC721_ADDRESS, TOKEN_MANAGER_ETH_ADDRESS, \
     TOKEN_MANAGER_ERC721_WITH_METADATA_ADDRESS, TOKEN_MANAGER_LINKER_ADDRESS
 from web3 import Web3
-from pkg_resources import get_distribution
 
 
 class MessageProxyForSchainGenerator(Generator):
@@ -97,7 +97,7 @@ class MessageProxyForSchainGenerator(Generator):
         cls._write_uint256(storage, inited_slot, 1)
         cls._write_uint256(storage, cls.GAS_LIMIT_SLOT, cls.GAS_LIMIT)
         cls._write_string(storage, cls.VERSION_SLOT,
-                          get_distribution('ima_predeployed').version)
+                          version('ima-predeployed'))
         registry_contracts_slot = Generator.calculate_mapping_value_slot(
             cls.REGISTRY_CONTRACTS_SLOT, cls.ANY_SCHAIN, 'bytes32')
         allowed_contracts = [

--- a/predeployed/test/contracts/message_proxy_for_schain.py
+++ b/predeployed/test/contracts/message_proxy_for_schain.py
@@ -1,9 +1,10 @@
+from importlib.metadata import version
+
 from ima_predeployed.addresses import MESSAGE_PROXY_FOR_SCHAIN_ADDRESS, KEY_STORAGE_ADDRESS, \
     TOKEN_MANAGER_ETH_ADDRESS, TOKEN_MANAGER_ERC20_ADDRESS, COMMUNITY_LOCKER_ADDRESS, TOKEN_MANAGER_ERC721_ADDRESS, \
     TOKEN_MANAGER_ERC1155_ADDRESS, TOKEN_MANAGER_ERC721_WITH_METADATA_ADDRESS, TOKEN_MANAGER_LINKER_ADDRESS
 from ima_predeployed.contracts.message_proxy_for_schain import MessageProxyForSchainGenerator
 from tools import load_abi, w3
-from pkg_resources import get_distribution
 
 
 def check_message_proxy_for_schain(owner_address, schain_name):
@@ -62,5 +63,5 @@ def check_message_proxy_for_schain(owner_address, schain_name):
     if not message_proxy_for_schain.functions.isContractRegistered(MessageProxyForSchainGenerator.ANY_SCHAIN,
                                                                 COMMUNITY_LOCKER_ADDRESS).call():
         raise AssertionError
-    if not message_proxy_for_schain.functions.version().call() == get_distribution('ima_predeployed').version:
+    if not message_proxy_for_schain.functions.version().call() == version('ima-predeployed'):
         raise AssertionError


### PR DESCRIPTION
This pull request updates the way the package version is retrieved in both the contract generator and its tests, switching from `pkg_resources.get_distribution` to `importlib.metadata.version`. This modernizes the codebase and removes a dependency on `pkg_resources`. Fixes #1810 

**Dependency update and code modernization:**

* Replaced `pkg_resources.get_distribution('ima_predeployed').version` with `importlib.metadata.version('ima-predeployed')` in `MessageProxyForSchainGenerator.generate_storage` to retrieve the package version in a more modern and efficient way. [[1]](diffhunk://#diff-4c7f5776bbb7abe5767ce3d7551a8a6a32e3205231bce37a01bfafc305c0e3f1R2) [[2]](diffhunk://#diff-4c7f5776bbb7abe5767ce3d7551a8a6a32e3205231bce37a01bfafc305c0e3f1L13) [[3]](diffhunk://#diff-4c7f5776bbb7abe5767ce3d7551a8a6a32e3205231bce37a01bfafc305c0e3f1L100-R100)
* Updated the test in `predeployed/test/contracts/message_proxy_for_schain.py` to use `importlib.metadata.version('ima-predeployed')` for version checking, aligning it with the updated implementation and removing the `pkg_resources` import. [[1]](diffhunk://#diff-89f0c7621d867e6543093dabe2521c5d194ceb4b5fa5f50c0c0928a4f8ff17f0R1-L6) [[2]](diffhunk://#diff-89f0c7621d867e6543093dabe2521c5d194ceb4b5fa5f50c0c0928a4f8ff17f0L65-R66)